### PR TITLE
improved AvoidRecreatingDateTimeFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # PMD-jpinpoint-rules
 PMD rule set for performance aware Java coding, sponsored by Rabobank. The project is meant for creating and managing 
 automatic java code checks. 
-These checks are based on what we have learnt in several years of analyzing performance problems and other defects and failures 
+These checks are based on what we have learned in several years of analyzing performance problems and other defects and failures 
 found in code, tests and production situations.
 
 We didn't find these checks in other places, like the the standard PMD, FindBugs/Spotbugs, Checkstyle or Sonar rules.
 If you find duplicates of existing ones, please let us know. 
 We offered these rules to the PMD-team for inclusion in the standard rules and we were warmly welcomed. We have been working with them to upgrade and merge (some of) the jpinpoint rules in the standard and looking for sponsorship to continue with that.
 You don't have to wait for that, you can already use these as custom rules right now.
+
 The jpinpoint rules can be run from the command-line using the PMD tool, from your favorite development
 environment with a PMD-plugin, or in SonarQube after packaging them as Sonar plugin.
 
@@ -27,8 +28,8 @@ To use the ruleset you can install:
 
 After installing the tool you can run `pmd.sh` or `pmd.bat` similar to the following
 
-    pmd.bat \
-        -R PMD-jPinpoint-rules/rulesets/java/jpinpoint-rules.xml 
+    pmd.sh \
+        -R PMD-jPinpoint-rules/rulesets/java/jpinpoint-rules.xml \
         -d $your-project-src \
         -f text
 
@@ -67,6 +68,10 @@ Download it from the [PMD project at github](https://pmd.github.io/) and install
 After installation and configuration you can start the designer from the command prompt:
 
     designer.bat
+   
+or
+
+    ./run.sh designer
 
 ## Rules and unit tests
 
@@ -102,7 +107,7 @@ Or to add only a Test class and unit test xml file (steps 1 and 3).
 
 ### Conventions for XML Unit test files
 
-Following are some conventions and reccomendations on how to
+Following are some conventions and recommendations on how to
 construct the unit test files:
 
 - separate test code *(create separate ``<test-code>`` blocks)*

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -396,21 +396,25 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             formatter from a pattern only once, to initialize a static final field.
             (jpinpoint-rules)</description>
         <properties>
-            <property name="version" value="1.0"/>
+            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
-    //FieldDeclaration[@Final='false' or @Static='false']//ReferenceType/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')] |
-    //MethodDeclaration/Block//ReferenceType/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')]
-[ancestor::LocalVariableDeclaration/VariableDeclarator/VariableInitializer/Expression//PrimaryPrefix/Literal] |
-    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'ISODateTimeFormat.')] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'DateTimeFormat.')
-       and not (ends-with(@Image, 'forPattern'))] |
-   //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'DateTimeFormat.forPattern')]
-[ancestor::Expression//PrimaryPrefix/Literal] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimarySuffix[@Image='toFormatter']
-]]>
+    //FieldDeclaration[@Final=false()]//ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')],
+    //FieldDeclaration[@Final=true() and @Static=false()]//ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')](: has assignment, otherwise check in constructor :)[ancestor::ClassOrInterfaceBodyDeclaration//VariableInitializer],
+    //ConstructorDeclaration/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormat.forPattern')]
+(: check if parameter is argument of constructor call :)[not(ancestor::BlockStatement//Expression/PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=ancestor::ConstructorDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')],
+    //MethodDeclaration/Block/BlockStatement//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormatter.ofPattern')]
+(: check if parameter is argument of method call :)[not(ancestor::LocalVariableDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=
+ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[contains(@Image, 'ISODateTimeFormat.')],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[contains(@Image, 'DateTimeFormat.fullDateTime')],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormat.forPattern')]
+(: check if parameter is argument of method call :)[not(ancestor::LocalVariableDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=
+ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatterBuilder')][ancestor::PrimaryExpression/PrimarySuffix[@Image="toFormatter"]]
+                   ]]>
                 </value>
             </property>
         </properties>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -354,21 +354,25 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             formatter from a pattern only once, to initialize a static final field.
             (jpinpoint-rules)</description>
         <properties>
-            <property name="version" value="1.0"/>
+            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
-    //FieldDeclaration[@Final='false' or @Static='false']//ReferenceType/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')] |
-    //MethodDeclaration/Block//ReferenceType/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')]
-[ancestor::LocalVariableDeclaration/VariableDeclarator/VariableInitializer/Expression//PrimaryPrefix/Literal] |
-    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[typeIs('org.joda.time.format.DateTimeFormatter') or typeIs('org.threeten.bp.format.DateTimeFormatter') or typeIs('java.time.format.DateTimeFormatter')] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'ISODateTimeFormat.')] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'DateTimeFormat.')
-       and not (ends-with(@Image, 'forPattern'))] |
-   //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'DateTimeFormat.forPattern')]
-[ancestor::Expression//PrimaryPrefix/Literal] |
-    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimarySuffix[@Image='toFormatter']
-]]>
+    //FieldDeclaration[@Final=false()]//ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')],
+    //FieldDeclaration[@Final=true() and @Static=false()]//ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')](: has assignment, otherwise check in constructor :)[ancestor::ClassOrInterfaceBodyDeclaration//VariableInitializer],
+    //ConstructorDeclaration/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormat.forPattern')]
+(: check if parameter is argument of constructor call :)[not(ancestor::BlockStatement//Expression/PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=ancestor::ConstructorDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatter') or pmd-java:typeIs('org.threeten.bp.format.DateTimeFormatter') or pmd-java:typeIs('java.time.format.DateTimeFormatter')],
+    //MethodDeclaration/Block/BlockStatement//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormatter.ofPattern')]
+(: check if parameter is argument of method call :)[not(ancestor::LocalVariableDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=
+ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[contains(@Image, 'ISODateTimeFormat.')],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[contains(@Image, 'DateTimeFormat.fullDateTime')],
+    //MethodDeclaration/Block/BlockStatement//Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'DateTimeFormat.forPattern')]
+(: check if parameter is argument of method call :)[not(ancestor::LocalVariableDeclaration//PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name/@Image=
+ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Image)],
+    //MethodDeclaration/Block/BlockStatement//Expression//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.format.DateTimeFormatterBuilder')][ancestor::PrimaryExpression/PrimarySuffix[@Image="toFormatter"]]
+                   ]]>
                 </value>
             </property>
         </properties>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidRecreatingDateTimeFormatter.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidRecreatingDateTimeFormatter.xml
@@ -4,43 +4,44 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description>Avoid recreation of DateTimeFormatter object</description>
-        <expected-problems>14</expected-problems>
+        <description>Avoid recreation of DateTimeFormatter object.</description>
+        <expected-problems>13</expected-problems>
+        <expected-linenumbers>4,5,6,14,17,20,23,27,30,34,46,53,57</expected-linenumbers>
         <code><![CDATA[
 import org.joda.time.format.*;
 
-public class CreateDateTimeFormatterOnceTest {
-    final org.joda.time.format.DateTimeFormatter wrong = ISODateTimeFormat.basicDate();
-    static DateTimeFormatter wrongAgain = ISODateTimeFormat.basicDate();
-    DateTimeFormatter stillWrong = ISODateTimeFormat.basicDate();
-    static final DateTimeFormatter cigar = DateTimeFormat.forPattern("xxx");
-    private static final DateTimeFormatter ok = DateTimeFormat.forPattern("xxx");
+public class Foo {
+    final org.joda.time.format.DateTimeFormatter wrong = ISODateTimeFormat.basicDate(); // bad, not static
+    static DateTimeFormatter wrongAgain = ISODateTimeFormat.basicDate(); // bad, not final
+    DateTimeFormatter stillWrong = ISODateTimeFormat.basicDate(); // bad, not final, not static
+    static final DateTimeFormatter ok1 = DateTimeFormat.forPattern("xxx");
+    private static final DateTimeFormatter ok2 = DateTimeFormat.forPattern("xxx");
     public static final org.threeten.bp.format.DateTimeFormatter YMD_FORMATTER = org.threeten.bp.format.DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
 
     public void testViolation1(DateTimePrinter printer, DateTimeParser parser)  {
         DateTimeFormatter dtf = null;
-        dtf = new DateTimeFormatter(printer, parser);
+        dtf = new DateTimeFormatter(printer, parser); // bad
     }
     public void testViolation2()  {
-        DateTimeFormatter dtf =  new DateTimeFormatterBuilder().toFormatter();
+        DateTimeFormatter dtf =  new DateTimeFormatterBuilder().toFormatter(); // bad
     }
     public void testViolation3()  {
-        DateTimeFormatter dtf = ISODateTimeFormat.date();
+        DateTimeFormatter dtf = ISODateTimeFormat.date(); // bad
     }
     public void testViolation4()  {
-        stillWrong = DateTimeFormat.fullDateTime();
+        stillWrong = DateTimeFormat.fullDateTime(); // bad
     }
 
     public void testViolation5()  {
-        stillWrong = DateTimeFormat.forPattern("");
+        stillWrong = DateTimeFormat.forPattern(""); // bad
     }
     public void testViolation6(DateTimePrinter printer,DateTimeParser parser)  {
-        stillWrong =  new DateTimeFormatter(printer, parser);
+        stillWrong =  new DateTimeFormatter(printer, parser); // bad
     }
     public void testViolation7_PCC_171() {
         long dt = 1L;
-        String s = DateTimeFormat.forPattern("yyDDD").print(dt);
+        String s = DateTimeFormat.forPattern("yyDDD").print(dt); // bad
     }
 
     public DateTimeFormatter testNoViolation(){
@@ -52,20 +53,57 @@ public class CreateDateTimeFormatterOnceTest {
     }
 
     private DateTimeFormatter getDateTimeFormatterFromCacheViolation(String dateFormat) {
-        return new DateTimeFormatterBuilder().toFormatter(); // wrong
+        return new DateTimeFormatterBuilder().toFormatter(); // bad
     }
     public void testNoViolation_2(String dateFormat) {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(dateFormat);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(dateFormat); // good: possible different dataFormat params
     }
 
     public void testViolationThreeten() {
-        org.threeten.bp.format.DateTimeFormatter ftor = org.threeten.bp.format.DateTimeFormatter.ofPattern("yyMMdd");
+        org.threeten.bp.format.DateTimeFormatter ftor = org.threeten.bp.format.DateTimeFormatter.ofPattern("yyMMdd"); // bad
     }
 
     public void testViolationJava8() {
-        java.time.format.DateTimeFormatter ftor = java.time.format.DateTimeFormatter.ofPattern("yyMMdd");
+        java.time.format.DateTimeFormatter ftor = java.time.format.DateTimeFormatter.ofPattern("yyMMdd"); // bad
     }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>Avoid recreation of DateTimeFormatter object. But allow in constructor if member variable is final.</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>5,6,9</expected-linenumbers>
+        <code><![CDATA[
+import org.joda.time.format.*;
+public class Foo {
+    private final DateTimeFormatter ok;
+    private final DateTimeFormatter notok;
+    private final DateTimeFormatter notok2 = DateTimeFormat.forPattern("YY-MM-hh"); // bad (should be static)
+    private DateTimeFormatter notok3;
+    public Foo(String pattern) {
+        ok = DateTimeFormat.forPattern(pattern);
+        notok = DateTimeFormat.forPattern("YY-MM-hh"); // bad
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>Avoid recreation of DateTimeFormatter object. But allow if there is a parameter from method call involved.</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>7,8,9</expected-linenumbers>
+        <code><![CDATA[
+import org.joda.time.format.*;
 
+public class Foo {
+    private static final String DEFAULT_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static String format(final long milliseconds, String myFormat, String myTimeZone) {
+        final DateTimeFormatter formatter1 = DateTimeFormat.forPattern(myFormat); // good: has variable parameter
+        final DateTimeFormatter formatter2 = DateTimeFormat.forPattern(DEFAULT_DATETIME_FORMAT); // bad
+        final DateTimeFormatter formatter3 = DateTimeFormat.forPattern(DEFAULT_DATETIME_FORMAT).withZoneUTC(); // bad
+        final DateTimeFormatter formatter4 = DateTimeFormat.forPattern(DEFAULT_DATETIME_FORMAT).withZone(ZoneId.of("UTC")); // bad
+        final DateTimeFormatter formatter5 = DateTimeFormat.forPattern(DEFAULT_DATETIME_FORMAT).withZone(myTimeZone); // good: has variable parameter
+        return formatter1.print(milliseconds);
+    }
 }
      ]]></code>
     </test-code>


### PR DESCRIPTION
added missing cases and allow construction with parameters in some cases

this is for 

JPCC-58: False positive? DateTimeFormatter created in the constructor because it needs some String input first

and

JPCC-64: DateTimeFormatter creation in constructor is only done once, should not be flagged

and also for this case:

TODO lookup and add issue in github project
