### PR TITLE
fix for issue-125: there are two names for same timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
             <artifactId>httpasyncclient</artifactId>
             <version>4.1.4</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.3.7</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -2532,7 +2532,7 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
     </rule>
 
     <rule name="HttpClientBuilderWithoutTimeouts" class="net.sourceforge.pmd.lang.rule.XPathRule" deprecated="false" dfa="false" language="java"
-          message="HttpClient builder is used and not all three timeouts are configured (connectionRequestTimeout, connectTimeout, socketTimeout). HttpClient defaults are probably not optimal (e.g. infinite). Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts." typeResolution="true"
+          message="HttpClient builder is used and not all three timeouts are configured: connectionRequestTimeout, connectTimeout, socketTimeout (for HttpComponentsClientHttpRequestFactory) or readTimeout (for RequestConfig). HttpClient defaults are probably not optimal (e.g. infinite). Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts." typeResolution="true"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#IBI10">
         <description>Problem: the default timeout settings are not optimal in most cases, set the timeouts explicitly to proper reasoned values. See best practice values via the link. (jpinpoint-rules)</description>
         <priority>2</priority>
@@ -2574,13 +2574,13 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
    and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])<3
 ]
 ,
-(: HttpComponentsClientHttpRequestFactory with httpClient and with not all three of setConnectionRequestTimeout/setConnectTimeout/setReadTimeout :)
+(: HttpComponentsClientHttpRequestFactory with local httpClient and with not all three of setConnectionRequestTimeout/setConnectTimeout/[setReadTimeout or setSocketTimeout] :)
 //MethodDeclaration//AllocationExpression/ClassOrInterfaceType[
    pmd-java:typeIs('org.springframework.http.client.HttpComponentsClientHttpRequestFactory')
    and (ancestor::Block//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setHttpClient')]
         or ancestor::Expression//Arguments//PrimaryPrefix[pmd-java:typeIs('org.apache.http.client.HttpClient')])
-   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])<3
-   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])>0
+   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout') or ends-with(@Image, 'setSocketTimeout')])<3
+   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout') or ends-with(@Image, 'setSocketTimeout')])>0
 ]
 ,
 (: HttpComponentsClientHttpRequestFactory as param and with not all three of setConnectionRequestTimeout/setConnectTimeout/setReadTimeout :)

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -277,7 +277,7 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
     </rule>
 
     <rule name="HttpClientBuilderWithoutTimeouts" class="net.sourceforge.pmd.lang.rule.XPathRule" deprecated="false" dfa="false" language="java"
-          message="HttpClient builder is used and not all three timeouts are configured (connectionRequestTimeout, connectTimeout, socketTimeout). HttpClient defaults are probably not optimal (e.g. infinite). Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts." typeResolution="true"
+          message="HttpClient builder is used and not all three timeouts are configured: connectionRequestTimeout, connectTimeout, socketTimeout (for HttpComponentsClientHttpRequestFactory) or readTimeout (for RequestConfig). HttpClient defaults are probably not optimal (e.g. infinite). Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts." typeResolution="true"
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#IBI10">
         <description>Problem: the default timeout settings are not optimal in most cases, set the timeouts explicitly to proper reasoned values. See best practice values via the link. (jpinpoint-rules)</description>
         <priority>2</priority>
@@ -319,13 +319,13 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
    and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])<3
 ]
 ,
-(: HttpComponentsClientHttpRequestFactory with httpClient and with not all three of setConnectionRequestTimeout/setConnectTimeout/setReadTimeout :)
+(: HttpComponentsClientHttpRequestFactory with local httpClient and with not all three of setConnectionRequestTimeout/setConnectTimeout/[setReadTimeout or setSocketTimeout] :)
 //MethodDeclaration//AllocationExpression/ClassOrInterfaceType[
    pmd-java:typeIs('org.springframework.http.client.HttpComponentsClientHttpRequestFactory')
    and (ancestor::Block//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setHttpClient')]
         or ancestor::Expression//Arguments//PrimaryPrefix[pmd-java:typeIs('org.apache.http.client.HttpClient')])
-   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])<3
-   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout')])>0
+   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout') or ends-with(@Image, 'setSocketTimeout')])<3
+   and count(ancestor::MethodDeclaration//(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'setConnectionRequestTimeout') or ends-with(@Image, 'setConnectTimeout') or ends-with(@Image, 'setReadTimeout') or ends-with(@Image, 'setSocketTimeout')])>0
 ]
 ,
 (: HttpComponentsClientHttpRequestFactory as param and with not all three of setConnectionRequestTimeout/setConnectTimeout/setReadTimeout :)

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/HttpClientBuilderWithoutTimeouts.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/HttpClientBuilderWithoutTimeouts.xml
@@ -181,14 +181,42 @@ class Good {
             factory.setHttpClient(client); // good
         return factory;
     }
+
+    public HttpComponentsClientHttpRequestFactory good3() {
+
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectionRequestTimeout(350)
+            .setConnectTimeout(250)
+            .setSocketTimeout(4000)
+            .build(); // good, all timeouts set
+
+        HttpClient client = HttpClientBuilder.create()
+            .setDefaultRequestConfig(requestConfig) // good, all timeouts set, if missing > default timeouts?
+            .build();
+
+        HttpComponentsClientHttpRequestFactory factory =
+            new HttpComponentsClientHttpRequestFactory();
+            factory.setHttpClient(client); // good
+
+        return factory;
+    }
+
+    public HttpComponentsClientHttpRequestFactory good4(HttpClient client) {
+
+        HttpComponentsClientHttpRequestFactory factory =
+            new HttpComponentsClientHttpRequestFactory();
+            factory.setHttpClient(client); // good
+
+        return factory;
+    }
  }
      ]]></code>
     </test-code>
 
     <test-code>
         <description>violation: Spring HttpComponentsClientHttpRequestFactory and explicit HttpClient and explicit timeouts, but not all three timeouts set</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>7,13</expected-linenumbers>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>7,13,30</expected-linenumbers>
         <code><![CDATA[
 import org.apache.http.client.HttpClient;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -206,6 +234,23 @@ class Bad {
         factory.setHttpClient(client);
         factory.setReadTimeout(4000);
         return factory.getHttpClient();
+    }
+    public HttpComponentsClientHttpRequestFactory bad3() {
+
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectionRequestTimeout(350)
+            .setConnectTimeout(250)
+            .build(); // bad, socketTimeout is missing
+
+        HttpClient client = HttpClientBuilder.create()
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+
+        HttpComponentsClientHttpRequestFactory factory =
+            new HttpComponentsClientHttpRequestFactory();
+            factory.setHttpClient(client); // bad, see missing timeout above
+
+        return factory;
     }
 }
      ]]></code>


### PR DESCRIPTION
there are two names for same timeout: socketTimeout (for HttpComponentsClientHttpRequestFactory) or readTimeout (for RequestConfig)