### PR TITLE
Issue-236: Default feign client without tls connection reuse

### DIFF
--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -3616,6 +3616,47 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="DefaultFeignClientWithoutTLSConnectionReuse" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java"
+          message="Default Feign client is used with (mutual) TLS. This is HttpURLConnection that creates new connection for each call with TLS overhead." typeResolution="true"
+          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#ibi21">
+        <description>Problem: the default http client of Feign is java.net.HttpURLConnection that does not pool connections when using mutual TLS. This causes connection handshake overhead: extra CPU and latency.&#13;
+            Solution: switch to a Feign client that supports HTTP connection pooling with mTLS, for instance Apache HttpClient 4 with disableConnectionState and proper connection pool size and timeouts. (jpinpoint-rules)</description>
+        <priority>2</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value><![CDATA[
+(: default client constructor with sslSocketFactory :)
+//MethodDeclaration//PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('feign.Client.Default')
+and not(ancestor::Expression//Arguments[ArgumentList/@Size=2]//Expression[1]//NullLiteral)]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+import feign.Client;
+
+public class MyFeignClient {
+
+    public Client createClient(SSLSocketFactory sslSocketFactory){
+        return new Client.Default(sslSocketFactory, null); // bad
+    }
+
+    public Client createClient(){
+        return new Client.Default(null, null); // good
+    }
+
+    public Feign.Builder feignBuilder() {
+        Client feignClient =
+            new Client.Default(setupSSLContextForMutualTLS().getSocketFactory(), new DefaultHostnameVerifier()); // bad
+        return Feign.builder().client(feignClient);
+    }
+}
+            ]]>
+        </example>
+    </rule>
+
     <rule name="GsonCreatedForEachMethodCall" message="A Gson object is created for each method call, which is expensive." class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java"   typeResolution="true" externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#IUOJAR03">
         <description>Problem: Gson creation is relatively expensive. A JMH benchmark shows a 24x improvement reusing one instance. &#13;
             Solution: Since Gson objects are thread-safe after creation, they can be between threads. So, reuse created instances, from a static field. Pay attention

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -134,9 +134,9 @@ or preceding-sibling::SwitchLabel[@Default=true()])
     </rule>
 
     <rule name="AvoidImplicitlyRecompilingRegex" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java" message="String regex method, Pattern.matches or FileSystem.getPathMatcher is used.
-	   Implicitely compiles a regex pattern, can be expensive." typeResolution="true"
+	   Implicitly compiles a regex pattern, can be expensive." typeResolution="true"
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#ireu01">
-        <description>A regular expression is compiled implicitely on every invocation. Problem: this can be expensive, depending on the length of the regular expression.&#13;
+        <description>A regular expression is compiled implicitly on every invocation. Problem: this can be expensive, depending on the length of the regular expression.&#13;
             Solution: Compile the regex pattern only once and assign it to a private static final Pattern field. java.util.Pattern objects are thread-safe so they can be shared among threads.
             (jpinpoint-rules)</description>
         <priority>2</priority>

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -380,6 +380,47 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
         </example>
     </rule>
 
+    <rule name="DefaultFeignClientWithoutTLSConnectionReuse" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java"
+          message="Default Feign client is used with (mutual) TLS. This is HttpURLConnection that creates new connection for each call with TLS overhead." typeResolution="true"
+          externalInfoUrl="${doc_root}/JavaCodePerformance.md#ibi21">
+        <description>Problem: the default http client of Feign is java.net.HttpURLConnection that does not pool connections when using mutual TLS. This causes connection handshake overhead: extra CPU and latency.&#13;
+            Solution: switch to a Feign client that supports HTTP connection pooling with mTLS, for instance Apache HttpClient 4 with disableConnectionState and proper connection pool size and timeouts. (jpinpoint-rules)</description>
+        <priority>2</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value><![CDATA[
+(: default client constructor with sslSocketFactory :)
+//MethodDeclaration//PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('feign.Client.Default')
+and not(ancestor::Expression//Arguments[ArgumentList/@Size=2]//Expression[1]//NullLiteral)]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+import feign.Client;
+
+public class MyFeignClient {
+
+    public Client createClient(SSLSocketFactory sslSocketFactory){
+        return new Client.Default(sslSocketFactory, null); // bad
+    }
+
+    public Client createClient(){
+        return new Client.Default(null, null); // good
+    }
+
+    public Feign.Builder feignBuilder() {
+        Client feignClient =
+            new Client.Default(setupSSLContextForMutualTLS().getSocketFactory(), new DefaultHostnameVerifier()); // bad
+        return Feign.builder().client(feignClient);
+    }
+}
+            ]]>
+        </example>
+    </rule>
+
     <rule name="AvoidJAXBUtil"
           language="java"
           message="The JAXB utility class is not optimized for performance."

--- a/src/main/resources/category/java/spring.xml
+++ b/src/main/resources/category/java/spring.xml
@@ -49,7 +49,7 @@ class Good {
         </example>
     </rule>
 
-    <rule name="AvoidModelMapAsRenderParameter" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java" message="A ModelMap or @ModelAttribute is used as parameter of a portlet render method and implicitely put in the session." typeResolution="true"
+    <rule name="AvoidModelMapAsRenderParameter" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java" message="A ModelMap or @ModelAttribute is used as parameter of a portlet render method and implicitly put in the session." typeResolution="true"
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#tmsu11">
         <description>Problem: ModelMaps are rather large objects containing explicitly added data and administrative data from Spring. They are added to the Portlet session implicitly. They stay in the session for some time: during session activity and 30 minutes (HTTP timeout) after it, in case the user does not exit explicitly. They occupy heap space during that time, for every user.&#13;
             Solution: Remove the ModelMap from the render method parameter list and create a new local ModelMap to use in the render request scope.

--- a/src/test/java/com/jpinpoint/perf/lang/java/ruleset/remoting/DefaultFeignClientWithoutTLSConnectionReuseTest.java
+++ b/src/test/java/com/jpinpoint/perf/lang/java/ruleset/remoting/DefaultFeignClientWithoutTLSConnectionReuseTest.java
@@ -1,0 +1,6 @@
+package com.jpinpoint.perf.lang.java.ruleset.remoting;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class DefaultFeignClientWithoutTLSConnectionReuseTest extends PmdRuleTst {
+}

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/DefaultFeignClientWithoutTLSConnectionReuse.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/DefaultFeignClientWithoutTLSConnectionReuse.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>violation: DefaultFeignClientWithoutTLSConnectionReuse</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,11</expected-linenumbers>
+        <code><![CDATA[
+import feign.Client;
+
+public class Foo {
+
+    public Client bad1(SSLSocketFactory sslSocketFactory){
+        return new Client.Default(sslSocketFactory, null); // violation
+    }
+
+    public Feign.Builder bad2() {
+        Client feignClient =
+            new Client.Default(setupSSLContextForMutualTLS().getSocketFactory(), new DefaultHostnameVerifier()); // violation
+        return Feign.builder().client(feignClient);
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no-violation: DefaultFeignClientWithoutTLSConnectionReuse</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import feign.Client;
+
+public class Foo {
+
+    public Client good(){
+        return new Client.Default(null, null); // no-violation
+    }
+}
+     ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
Added new rule: DefaultFeignClientWithoutTLSConnectionReuse for issue #236, please review. Thanks.