### PR TITLE
318 merge tag properties to comma separated tags property 

### DIFF
--- a/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/RulesetMerger.java
+++ b/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/RulesetMerger.java
@@ -22,6 +22,7 @@ public class RulesetMerger {
     public static final String JPINPOINT_RULES = "jpinpoint-rules";
 
     public static final String JPINPOINT_KOTLIN_RULES = "jpinpoint-kotlin-rules";
+    public static final Pattern VALUE_PATTERN = Pattern.compile("value=\"(.*?)\"");
 
     private enum Language {
         JAVA("Java", "java"), KOTLIN("Kotlin", "kotlin");
@@ -279,7 +280,9 @@ public class RulesetMerger {
     private static List<List<String>> parseSortIntoRuleLinesList(List<String> fileLines) {
         Map<String, List<String>> nameToLines = new TreeMap<>();
         boolean ruleStarted = false;
+        boolean propertiesStarted = false;
         List<String> currentRuleLines = new ArrayList<>();
+        List<String> currentPropertiesLines = new ArrayList<>();
         String currentRuleName = "<none>";
         for(String line : fileLines) {
             if (line.contains("<rule name")) {
@@ -294,10 +297,55 @@ public class RulesetMerger {
                 ruleStarted = false;
             }
             else if (ruleStarted) {
-                currentRuleLines.add(line);
+                if (line.contains("<properties")) { // collect all lines between the <properties> tags
+                    currentPropertiesLines = new ArrayList<>();
+                    currentRuleLines.add(line);
+                    propertiesStarted = true;
+                }
+                else if (line.contains("</properties")) {
+                    currentRuleLines.addAll(processProperties(currentPropertiesLines));
+                    currentRuleLines.add(line);
+                    propertiesStarted = false;
+                }
+                else if (propertiesStarted) {
+                    currentPropertiesLines.add(line);
+                }
+                else {
+                    currentRuleLines.add(line);
+                }
             }
         }
         return new ArrayList<>(nameToLines.values());
+    }
+
+    /**
+     * <p>All lines between the <pre><properties></properties></pre> tags are expected as input.</p>
+     *
+     * <p>All values of properties with <pre>name="tag"</pre> will be put into one property with <pre>name="tags"</pre>.
+     * The type and description fields of the property lines are ignored, the final tags property has:
+     * <pre>type="String" description="classification"</pre>.</p>
+     */
+    private static List<String> processProperties(List<String> propertiesLines) {
+        List<String> newPropertiesLines = new ArrayList<>();
+        List<String> tags = new ArrayList<>();
+
+        for (String line : propertiesLines) {
+            if (line.contains("<property name=\"tag\"")) { // assumes the property is on one line
+                Matcher matcher = VALUE_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    String tag = matcher.group(1);
+                    tags.add(tag);
+                }
+            }
+            else {
+                newPropertiesLines.add(line);
+            }
+        }
+        if (!tags.isEmpty()) {
+            Collections.sort(tags);
+            newPropertiesLines.add(String.format("            <property name=\"tags\" value=\"%s\" type=\"String\" description=\"classification\" />", StringUtils.join(tags, ",")));
+        }
+        return newPropertiesLines;
     }
 
     private static class MergeWithExternalHelper {

--- a/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/TagsMigration.java
+++ b/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/TagsMigration.java
@@ -38,7 +38,7 @@ public class TagsMigration {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            System.out.println("Error: " + e.getMessage());
         }
 
     }

--- a/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/TagsMigration.java
+++ b/rulesets-merger/src/main/java/com/jpinpoint/perf/tools/TagsMigration.java
@@ -1,0 +1,102 @@
+package com.jpinpoint.perf.tools;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TagsMigration {
+
+    public static final Pattern VALUE_PATTERN = Pattern.compile("value=\"(.*?)\"");
+
+    public static void main(String[] args) {
+
+        try {
+            // get the directory path
+            String directoryPath = "src/main/resources/category/java";
+            File dir = new File(directoryPath);
+
+            // Get all the files from a directory.
+            File[] fileList = dir.listFiles();
+            if (fileList != null) {
+                for (File file : fileList) {
+                    if (file.isFile() && file.getName().endsWith(".xml")) {
+                        // create a list of lines from file
+                        List<String> lines = Files.readAllLines(Paths.get(file.getPath()), StandardCharsets.UTF_8);
+
+                        // call the migrate function
+                        List<String> newLines = migrate(lines);
+
+                        // write the new lines into a new file
+                        Files.write(Paths.get(directoryPath + "/new_" + file.getName()), newLines, StandardCharsets.UTF_8);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    public static List<String> migrate(List<String> lines) {
+
+        boolean propertiesStarted = false;
+        List<String> newLines = new ArrayList<>();
+        List<String> currentPropertiesLines = new ArrayList<>();
+
+        for (String line : lines) {
+            if (line.contains("<properties")) { // collect all lines between the <properties> tags
+                currentPropertiesLines = new ArrayList<>();
+                newLines.add(line);
+                propertiesStarted = true;
+            } else if (line.contains("</properties")) {
+                newLines.addAll(processProperties(currentPropertiesLines));
+                newLines.add(line);
+                propertiesStarted = false;
+            } else if (propertiesStarted) {
+                currentPropertiesLines.add(line);
+            } else {
+                newLines.add(line);
+            }
+        }
+        return newLines;
+    }
+
+    /**
+     * <p>All lines between the <pre><properties></properties></pre> tags are expected as input.</p>
+     *
+     * <p>All values of properties with <pre>name="tag"</pre> will be put into one property with <pre>name="tags"</pre>.
+     * The type and description fields of the property lines are ignored, the final tags property has:
+     * <pre>type="String" description="classification"</pre>.</p>
+     */
+    private static List<String> processProperties(List<String> propertiesLines) {
+        List<String> newPropertiesLines = new ArrayList<>();
+        List<String> tags = new ArrayList<>();
+
+        for (String line : propertiesLines) {
+            if (line.contains("<property name=\"tag\"")) { // assumes the property is on one line
+                Matcher matcher = VALUE_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    String tag = matcher.group(1);
+                    tags.add(tag);
+                }
+            }
+            else {
+                newPropertiesLines.add(line);
+            }
+        }
+        // re-add the version tag for PMD-6
+        newPropertiesLines.add("            <property name=\"version\" value=\"2.0\"/>");
+        if (!tags.isEmpty()) {
+            Collections.sort(tags);
+            newPropertiesLines.add(String.format("            <property name=\"tags\" value=\"%s\" type=\"String\" description=\"classification\"/>", StringUtils.join(tags, ",")));
+        }
+        return newPropertiesLines;
+    }
+
+}

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -22,10 +22,6 @@
         (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Expression/PrimaryExpression/PrimaryPrefix/Name[@Image='CDI.current']/../../
@@ -46,6 +42,7 @@ PrimarySuffix[@Image = 'select']/ancestor::VariableDeclarator/VariableDeclarator
 ])]
 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -81,10 +78,6 @@ public class CDIStuff {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //(Type)[pmd-java:typeIs('java.util.Calendar')]
@@ -92,6 +85,7 @@ public class CDIStuff {
 //Name[starts-with(@Image, 'Calendar.')]
 	         ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -119,13 +113,12 @@ public class CalendarStuff {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
  //ClassOrInterfaceDeclaration[@Interface=true()]/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -147,13 +140,12 @@ public interface Foo {
         (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/VariableDeclarator/VariableInitializer/Expression[pmd-java:typeIs('java.text.DecimalFormat') or pmd-java:typeIs('java.text.ChoiceFormat')]
         ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -167,8 +159,6 @@ public interface Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -188,6 +178,7 @@ or preceding-sibling::SwitchLabel[@Default=true()])
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -202,8 +193,6 @@ or preceding-sibling::SwitchLabel[@Default=true()])
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //RecordDeclaration//RecordComponent/Type[(pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map'))
@@ -211,6 +200,7 @@ and
 not(../VariableDeclaratorId/@Name = ancestor::RecordDeclaration/RecordBody/CompactConstructorDeclaration//StatementExpression
 [Expression//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'copyOf')]]/PrimaryExpression/PrimaryPrefix/Name/@Image)]                ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -234,10 +224,6 @@ record GoodRecord(String name, List<String> list) {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//MethodDeclaration//(PrimaryPrefix/Name[ends-with(@Image, '.replaceAll') or ends-with(@Image, '.replaceFirst') or @Image='Pattern.matches']
@@ -304,6 +290,7 @@ VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Literal[string-le
 ]])
 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -330,10 +317,6 @@ String good_replaceInnerLineBreakBySpace() {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.ByteArrayOutputStream') or pmd-java:typeIs('java.io.StringWriter')]
@@ -345,6 +328,7 @@ or
 ]/..
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -380,15 +364,12 @@ class Good {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[@Image='Files.readAllBytes' or @Image='Files.readAllLines']
                 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -423,9 +404,6 @@ class Good {
         (jpinpoint-rules)</description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unused" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //(TypeDeclaration|ClassOrInterfaceBodyDeclaration/ClassOrInterfaceDeclaration/..)/Annotation
@@ -433,6 +411,7 @@ class Good {
     [count(..//FieldDeclaration) = 0]
                 ]]></value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule,unused" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -451,10 +430,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block[
@@ -478,6 +453,7 @@ and
 ]) > 1 ]//BlockStatement[position()=last()]//StatementExpression/Expression/AdditiveExpression[@Operator = '+']
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -492,8 +468,6 @@ and
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     (: a field of type List :)
@@ -528,6 +502,7 @@ not(@Name = ancestor::ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/Metho
     )]
 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,pitfall" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -564,10 +539,6 @@ public class Good {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //EnumDeclaration/EnumBody[count(EnumConstant) > 3]//MethodDeclaration/Block//PrimaryExpression
@@ -576,6 +547,7 @@ public class Good {
     [PrimarySuffix[starts-with(@Image, 'find')]]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -625,10 +597,6 @@ public enum Fruit {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -639,6 +607,7 @@ and not (
 ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Name)]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -672,10 +641,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration//ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -685,6 +650,7 @@ class Good {
 or (pmd-java:typeIs('javax.xml.xpath.XPath') and ends-with(@Image, 'evaluate'))]
 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -733,10 +699,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -757,6 +719,7 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
                    ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -771,11 +734,6 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[not((@Name='main' and @Static=true())or ../Annotation//Name/@Image='PostConstruct'
@@ -784,6 +742,7 @@ or .//IfStatement//EqualityExpression[@Operator='=='][
 //AllocationExpression[pmd-java:typeIs('java.security.Provider')]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -817,10 +776,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/AllocationExpression/ClassOrInterfaceType
@@ -841,6 +796,7 @@ class Foo {
 	]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -851,10 +807,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[
@@ -867,6 +819,7 @@ class Foo {
 ]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -876,15 +829,12 @@ class Foo {
             Solution: Replace StringBuffer by StringBuilder.  (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
                     //VariableDeclarator[../Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.StringBuffer')]]
                     ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -895,8 +845,6 @@ class Foo {
             Solution: Specify the time unit in the identifier, like connectTimeoutMillis. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -912,6 +860,7 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -932,8 +881,6 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
             Solution: Specify the time unit in the identifier, like connectTimeoutMillis. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -949,6 +896,7 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -969,10 +917,6 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement/Statement//StatementExpression/PrimaryExpression/PrimaryPrefix/Name[
@@ -994,6 +938,7 @@ substring-after(@Image, '.') != 'append')]) = 0
 ]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -1009,8 +954,6 @@ substring-after(@Image, '.') != 'append')]) = 0
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: append used in one chained statement on allocated StringBuilder and with chained toString :)
@@ -1037,6 +980,7 @@ and not(substring-before(@Image, '.') = ancestor::Block//Statement//PrimarySuffi
 ]
 	         ]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1067,10 +1011,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -1082,6 +1022,7 @@ and
 ]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -1092,16 +1033,13 @@ and
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
 //PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'XPathAPI.')]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -1112,10 +1050,6 @@ and
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/
@@ -1124,6 +1058,7 @@ ClassOrInterfaceBodyDeclaration
 [not (ancestor::FieldDeclaration//ClassOrInterfaceType/@Image = 'ThreadLocal')]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -1140,11 +1075,6 @@ ClassOrInterfaceBodyDeclaration
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Resource//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.FileInputStream') or pmd-java:typeIs('java.io.FileOutputStream')]
@@ -1152,6 +1082,7 @@ ClassOrInterfaceBodyDeclaration
 [not (ancestor::TryStatement//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.BufferedInputStream') or pmd-java:typeIs('BufferedOutputStream')])]
 ]]></value>
             </property>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1186,11 +1117,6 @@ class BufferFileStreaming {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[pmd-java:typeIs('java.nio.file.Files') and ends-with(@Image,'.newOutputStream')]
@@ -1202,6 +1128,7 @@ and (not(.//PrimaryPrefix/Name[pmd-java:typeIs('org.apache.commons.io.IOUtils') 
 ]]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1223,8 +1150,6 @@ class Foo {
             Solution: When objects are equal, hashCode needs to be equal, too. Use the same fields in equals and hashCode and use identical conversions like toUpperCase() in both when needed. Don't use equalsIgnoreCase. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1244,6 +1169,7 @@ class Foo {
                 ]]>
                 </value>
             </property>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1319,8 +1245,6 @@ class Good {
             Solution: When objects are equal, hashCode needs to be equal, too. Use the same fields in equals and hashCode. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1332,6 +1256,7 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1381,8 +1306,6 @@ class Bad {
         (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[@Name='equals' and MethodDeclarator/FormalParameters/@Size=1 and @Public=true() and @Static=false()]
@@ -1390,6 +1313,7 @@ class Bad {
 /Block[count(./BlockStatement/Statement) = 1][count(.//ArgumentList) = 0]//PrimaryExpression[PrimaryPrefix[@SuperModifier=true()]]/PrimarySuffix[@Image='hashCode']
                 ]]></value>
             </property>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1435,8 +1359,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -1515,6 +1437,7 @@ ancestor::ClassOrInterfaceBodyDeclaration[1]/Annotation//Name[@Image='Getter']
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,unpredictable" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1557,9 +1480,6 @@ class LombokGetterGood {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //VariableDeclaratorId[matches(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN', 'i')
@@ -1567,6 +1487,7 @@ and replace(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN|_', ''
 or starts-with(@Name, 'var') and number(substring-after(@Name, 'var'))]
                 ]]></value>
             </property>
+            <property name="tags" value="bad-practice,confusing,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1590,9 +1511,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -1605,6 +1523,7 @@ and not((ancestor::MethodDeclaration//TryStatement/FinallyStatement//StatementEx
 ]]>
                 </value>
             </property>
+            <property name="tags" value="correctness,jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1640,10 +1559,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration/MethodDeclaration[../..//(VariableDeclaratorId |ReturnStatement/Expression)[pmd-java:typeIs('javax.portlet.PortletSession') or pmd-java:typeIs('javax.servlet.http.HttpSession')]]
@@ -1661,6 +1576,7 @@ ClassOrInterfaceBodyDeclaration//MethodDeclaration/Block//PrimaryExpression/Prim
 )]]
 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1697,8 +1613,6 @@ class Good {
             Solution: include the missing field in the equals and hashCode method. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration[@Static=false()]//VariableDeclaratorId[
@@ -1720,6 +1634,7 @@ class Good {
 			]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1753,8 +1668,6 @@ class Bad1 {
             Solution: Use the same fields in hashCode as are used in equals. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1766,6 +1679,7 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1818,10 +1732,6 @@ class Bad {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: check key/elem type in declaration :)
@@ -1842,6 +1752,7 @@ and (pmd-java:typeIs('java.lang.Object'))
 ]
                ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1881,10 +1792,6 @@ and (pmd-java:typeIs('java.lang.Object'))
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/Type[pmd-java:typeIs('java.util.Set') and ReferenceType//TypeArgument[1][not(pmd-java:typeIs('java.lang.Comparable'))
@@ -1908,6 +1815,7 @@ or ancestor::MethodDeclaration//PrimaryExpression/PrimaryPrefix/Name/@Image = co
 ]/../..
                ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -1951,11 +1859,6 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/ReferenceType/ClassOrInterfaceType
@@ -2002,6 +1905,7 @@ VariableDeclarator/VariableInitializer/Expression
 /TypeArguments/TypeArgument[1]/ReferenceType[pmd-java:typeIs('java.lang.Enum') or ClassOrInterfaceType/@Image = //EnumDeclaration/@SimpleName]]/VariableDeclarator/VariableDeclaratorId/@Name]
 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2017,10 +1921,6 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
             Solution: Use SLF4J formatting with {}-placeholders or log and format conditionally.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name[ends-with(@Image,'.trace') or ends-with(@Image,'.debug') or
@@ -2034,6 +1934,7 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
     ])]
 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
         <![CDATA[
@@ -2061,10 +1962,6 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name
@@ -2104,6 +2001,7 @@ class Foo {
 ]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2127,10 +2025,6 @@ class Foo {
             Solution: Execute the operation only conditionally and utilize SLF4J formatting with {}-placeholders.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
           //PrimaryPrefix/Name
@@ -2172,6 +2066,7 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2192,8 +2087,6 @@ class Foo {
             Solution: Suppress warnings judiciously based on full knowledge and report reasons to suppress (false positives) to the rule maintainers so the rule can be fixed. (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="ruleIdMatches" type="String" value=".*"
                       description="Regex for inclusion of rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
@@ -2204,6 +2097,7 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -2213,9 +2107,6 @@ class Foo {
             Solution: Suppress warnings judiciously based on full knowledge and report reasons to suppress (false positives) to the rule maintainers so the rule can be fixed. (jpinpoint-rules)</description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="ruleIdMatches" type="String" value="AvoidUnguardedMutableFieldsInSharedObjects|AvoidUnguardedAssignmentToNonFinalFieldsInSharedObjects|AvoidMutableStaticFields|[^\w]ALL[^\w]|[^\w]all[^\w]|PMD[^\.]|pmd[^:]"
                       description="Regex for inclusion of high risk rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
@@ -2226,6 +2117,7 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -2243,11 +2135,6 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2270,6 +2157,7 @@ class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="io,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2297,11 +2185,6 @@ public class FileStuff {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
@@ -2312,6 +2195,7 @@ PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'
 //ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
 	         ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2347,10 +2231,6 @@ public class DateStuff {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement[
@@ -2367,6 +2247,7 @@ ancestor::Block//LocalVariableDeclaration[@Final=true()]//VariableDeclaratorId/@
 ]]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2398,10 +2279,6 @@ public class StringStuff {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ForStatement | //WhileStatement | //DoStatement)//AssignmentOperator[
@@ -2416,6 +2293,7 @@ public class StringStuff {
 	]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2453,8 +2331,6 @@ public class StringStuff {
         (jpinpoint-rules)</description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression[(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'forEach')]]
@@ -2464,6 +2340,7 @@ public class StringStuff {
 )]
                 ]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2496,10 +2373,6 @@ public class StringStuff {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unused" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for each assignment node :)
@@ -2537,6 +2410,7 @@ return ($node[
 )
                 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,replaces-sonar-rule,suspicious,unused" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2557,9 +2431,6 @@ return ($node[
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[@Image='Serializable']
@@ -2579,6 +2450,7 @@ and (pmd-java:typeIs('java.lang.Object'))]))
 ]
                 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2619,9 +2491,6 @@ class Baz extends RemoteException {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="brain-overload" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-block-max" value="1" type="String" description="Maximum allowed depth of lambda-with-code-block nesting"/>
             <property name="param-single-max" value="4" type="String" description="Maximum allowed depth of lambda-single-expression nesting"/>
             <property name="xpath">
@@ -2631,6 +2500,7 @@ class Baz extends RemoteException {
 //LambdaExpression[Expression][count(ancestor::LambdaExpression) > number($param-single-max)]
                 ]]></value>
             </property>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2670,9 +2540,6 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="brain-overload" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="5" type="String" description="Maximum number of allowed non-setter statements"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -2682,6 +2549,7 @@ class Foo {
 ]
                 ]]></value>
             </property>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2726,10 +2594,6 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="3" type="String" description="Maximum number of allowed static imports with wildcard"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -2737,6 +2601,7 @@ class Foo {
 	]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2769,10 +2634,6 @@ import static com.co.corporate.Constants.GREAT; // good
             It assumes CPU intensive non-blocking processing of in-memory data.  (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: assumption: if import of web client / http client is present, parallelStreaming is for remote calls :)
@@ -2785,6 +2646,7 @@ and not(ancestor::Block//StatementExpression/PrimaryExpression/PrimaryPrefix/Nam
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2837,11 +2699,6 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-	        <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2852,6 +2709,7 @@ public class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall,unpredictable" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2884,10 +2742,6 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2909,6 +2763,7 @@ public class Foo {
 ]    ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -2923,10 +2778,6 @@ public class Foo {
             Solution: Provide a timeout to the invokeAll/invokeAny method and handle the timeout. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression[PrimarySuffix[@ArgumentCount=1]]/PrimaryPrefix
@@ -2934,6 +2785,7 @@ public class Foo {
 /../PrimarySuffix//ArgumentList
                 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -2961,9 +2813,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3004,6 +2853,7 @@ class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3028,10 +2878,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3062,6 +2908,7 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3097,8 +2944,6 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
             Solution: Guard the field properly with synchronized or use atomics like AtomicInteger. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/(AssignmentOperator[@Image='+=' or @Image='-=']/..|
@@ -3107,6 +2952,7 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
                         ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3144,11 +2990,6 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[@Image='MDC.setContextMap' and
@@ -3156,6 +2997,7 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 or ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter[pmd-java:typeIs('reactor.util.context.Context')])]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3198,8 +3040,6 @@ class FooGood {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3234,6 +3074,7 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3265,8 +3106,6 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3293,6 +3132,7 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3311,18 +3151,13 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimarySuffix[@Image='parallel' and ../PrimaryPrefix/Name[@Image = 'Flux.fromIterable']
 and //ImportDeclaration/Name[starts-with(@Image, 'reactor.core.publisher')]]
                 ]]></value>
             </property>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3359,12 +3194,6 @@ class FooGood {
             So only for large collections and much processing without having to wait.   (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/(PrimarySuffix[@Image='parallelStream' or @Image='parallel']|PrimaryPrefix/Name[ends-with(@Image, '.parallelStream') or ends-with(@Image, '.parallel')])
@@ -3375,6 +3204,7 @@ class FooGood {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low,unpredictable" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3435,15 +3265,12 @@ public class Foo {
             Solution: Just do processing when and where actually needed. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix/Name[@Image='Hooks.onEachOperator']
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3469,9 +3296,6 @@ public class FooBad {
             Solution: Use thread locals or create the Factories as local variables and anyway use properties to specify the implementation class. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBodyDeclaration//FieldDeclaration[@Static=true() and (
@@ -3488,6 +3312,7 @@ public class FooBad {
 			]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading,pitfall" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3511,8 +3336,6 @@ public class FooBad {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[pmd-java:typeIs('javax.xml.bind.Marshaller')
@@ -3521,6 +3344,7 @@ public class FooBad {
  or pmd-java:typeIs('javax.xml.validation.Validator')]
 			]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3537,8 +3361,6 @@ public class FooBad {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3557,6 +3379,7 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3575,9 +3398,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3613,6 +3433,7 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
 ]]>
                 </value>
             </property>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3632,8 +3453,6 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3662,6 +3481,7 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3681,9 +3501,6 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3721,6 +3538,7 @@ and not (../Annotation//Name[@Image='GuardedBy'])
 ]]>
                 </value>
             </property>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3740,9 +3558,6 @@ and not (../Annotation//Name[@Image='GuardedBy'])
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3776,6 +3591,7 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
                     ]]>
                 </value>
             </property>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -3787,11 +3603,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             Solution: Do *not* put the user related data in a shared object e.g. by Spring @Component annotation. Use a POJO. Or, if it is not user data, rename the field. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
-	        <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/Annotation//Name[(@Image='Component' or @Image='Service' or @Image='Controller' or @Image='RestController' or @Image='Repository' or
@@ -3807,6 +3618,7 @@ and not ((ancestor::TypeDeclaration/Annotation//Name[@Image='ConfigurationProper
 ]]>
                 </value>
             </property>
+            <property name="tags" value="correctness,data-mix-up,jpinpoint-rule,multi-threading,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3855,9 +3667,6 @@ public class VMRData {
             Solution: Since only one thread can access the field, there is no need for violatile and it can be removed. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //FieldDeclaration[@Volatile = true() and
@@ -3866,6 +3675,7 @@ public class VMRData {
                         ]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3895,8 +3705,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3933,6 +3741,7 @@ class Good {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -3972,8 +3781,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3988,6 +3795,7 @@ or ancestor::SynchronizedStatement/Expression//Name)]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4016,12 +3824,6 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             Solution: Remove synchronized because local variables are only accessible by the owning thread and are not shared. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-	        <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: var.x() in synchronized block, var in list of local vars and all var.x in synchronized block are local vars:)
@@ -4036,6 +3838,7 @@ count(distinct-values(ancestor::MethodDeclaration//LocalVariableDeclaration//Var
                         ]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4080,12 +3883,6 @@ public class Foo {
         (jpinpoint-rules)</description>
     <priority>3</priority>
     <properties>
-        <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-        <property name="tag" value="confusing" type="String" description="for-sonar"/>
-        <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-        <property name="tag" value="performance" type="String" description="for-sonar"/>
-        <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-        <property name="tag" value="cpu" type="String" description="for-sonar"/>
         <property name="xpath">
             <value>
                 <![CDATA[
@@ -4097,6 +3894,7 @@ and (count(ancestor::TypeDeclaration//MethodDeclaration[@Public=true() and not(e
                 ]]>
             </value>
         </property>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
     </properties>
     <example>
         <![CDATA[
@@ -4140,16 +3938,13 @@ class SingletonGood {
             Solution: Provide your own supplier with explicit pool sizing and timeouts by a class implementing Supplier. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[@Image='ClientHttpRequestFactorySupplier']
 [/CompilationUnit/ImportDeclaration/Name[starts-with(@Image, 'org.springframework.boot.web.client')]]]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule,performance,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4196,10 +3991,6 @@ and use it to replace the bad line in Bad example:
         Solutions: Upgrade to httpclient-4.5+ and use org.apache.http.impl.conn.PoolingHttpClientConnectionManager and e.g. org.apache.http.impl.client.HttpClientBuilder. (jpinpoint-rules)</description>
     <priority>2</priority>
     <properties>
-        <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-        <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-        <property name="tag" value="deprecated" type="String" description="for-sonar"/>
-        <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
         <property name="xpath">
             <value><![CDATA[
 //ImportDeclaration/Name[@Image='org.apache.commons.httpclient.SimpleHttpConnectionManager'
@@ -4228,6 +4019,7 @@ or pmd-java:typeIs('org.apache.commons.httpclient.MultiThreadedHttpConnectionMan
 ]
 		     ]]></value>
         </property>
+            <property name="tags" value="data-mix-up,deprecated,jpinpoint-rule,multi-threading" type="String" description="classification" />
     </properties>
         <example>
             <![CDATA[
@@ -4251,14 +4043,13 @@ class Good {
             Solution: Netflix recommends to use open source alternatives like resilience4j. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="deprecated" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImportDeclaration/Name[starts-with(@Image, "com.netflix.hystrix")]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="deprecated,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
         </example>
@@ -4273,8 +4064,6 @@ class Good {
             Solution: Don't use both on the same factory, provide the HttpClient only once to the factory. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Statement[StatementExpression[//ArgumentList]/PrimaryExpression/PrimaryPrefix/Name/@Image =
@@ -4283,6 +4072,7 @@ ancestor::MethodDeclaration//VariableDeclarator[.//AllocationExpression/ClassOrI
 ]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4321,10 +4111,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Type//ClassOrInterfaceType[@Image='SaajSoapMessageFactory'
@@ -4334,6 +4120,7 @@ and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[
 and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[@Image='System.setProperty'] and ./PrimarySuffix/Arguments//Literal[@Image='"javax.xml.transform.TransformerFactory"']])]
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4369,9 +4156,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/@TypeImage='int']/VariableDeclarator[VariableDeclaratorId[@Final = true()][contains(upper-case(@Name), 'TIMEOUT') or contains(upper-case(@Name), 'DURATIONOUT')
@@ -4379,6 +4163,7 @@ or(contains(upper-case(@Name), 'MAX') and contains(upper-case(@Name), 'ROUTE'))]
 [VariableInitializer//Literal or VariableDeclaratorId/@Name=ancestor::ClassOrInterfaceBody//ConstructorDeclaration//StatementExpression[Expression//Literal]//Name/@Image]
                 ]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4418,15 +4203,13 @@ class AvoidHardcodedConnectionConfig {
             Solution: Use the HttpHost constructor with 2 (including port) or preferably 3 arguments (including port and protocol). (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression[pmd-java:typeIs("org.apache.http.HttpHost")]/Arguments/ArgumentList[count(./Expression) = 1]/../..
 ]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4456,15 +4239,12 @@ class Foo {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('javax.xml.bind.JAXB')]
 	         ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4493,10 +4273,6 @@ public class XMLConversion {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[pmd-java:typeIs('io.github.resilience4j.retry.Retry') and ends-with(@Image, '.getEventPublisher')]
@@ -4507,6 +4283,7 @@ public class XMLConversion {
 /VariableDeclarator/VariableDeclaratorId/@Name), substring-before(@Image,'.')))]
                 ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4543,8 +4320,6 @@ public class Foo {
             Solution: Avoid configuring objectMappers except when initializing: right after construction. It is recommended to create ObjectReaders and ObjectWriters from ObjectMapper and pass those around since they are immutable and therefore thread-safe. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: exclude method annotated with PostConstruct :)
@@ -4570,6 +4345,7 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4608,8 +4384,6 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
             Also when used like jaxMsgConverter.setObjectMapper(objectMapper) it is not considered a violation. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (for $node in (//FieldDeclaration[pmd-java:typeIs('com.fasterxml.jackson.databind.ObjectMapper')
@@ -4626,6 +4400,7 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4650,16 +4425,13 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
             Solution: Remove Hooks.onOperatorDebug() when not debugging. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('reactor.core.publisher.Hooks')]//Name[ends-with(@Image, 'Hooks.onOperatorDebug')]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4681,10 +4453,6 @@ public class Foo {
             Solution: Create/build HttpClient with proper connection pooling and timeouts once, and then use it for requests. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
    //TypeDeclaration/ClassOrInterfaceDeclaration[count(.//Annotation//Name[@Image='Configuration']) = 0]
@@ -4694,6 +4462,7 @@ public class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4716,10 +4485,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/
@@ -4729,6 +4494,7 @@ FieldDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.
 MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.xml.datatype.XMLGregorianCalendar')]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -4744,16 +4510,13 @@ MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceT
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//VariableDeclarator[pmd-java:typeIs('io.axual.client.producer.Producer')]
 [ancestor::TypeDeclaration[count(./Annotation//Name[@Image='Configuration'])=0]]
 			]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4790,11 +4553,6 @@ class AxualProducerGood2{
             Solution: Avoid multiple reads of the response body so it is not needed. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: somehow typeIs does not work with spring-web-6.0, do it old school way :)
@@ -4803,6 +4561,7 @@ class AxualProducerGood2{
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4831,10 +4590,6 @@ public class Foo {
             Solution: switch to a Feign client that supports HTTP connection pooling with mTLS, for instance Apache HttpClient 4 with disableConnectionState and proper connection pool size and timeouts. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: default client constructor with sslSocketFactory :)
@@ -4843,6 +4598,7 @@ and not(ancestor::Expression//Arguments[ArgumentList/@Size=2]//Expression[1]//Nu
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4875,10 +4631,6 @@ public class MyFeignClient {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -4892,6 +4644,7 @@ public class MyFeignClient {
 ]
 			]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -4903,8 +4656,6 @@ public class MyFeignClient {
             2. not use a ConnectionManager and call setMaxConnTotal and setMaxConnPerRoute on the client directly (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder with setConnectionManager and at least one of setMaxConnTotal/setMaxConnPerRoute :)
@@ -4929,6 +4680,7 @@ public class MyFeignClient {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -4956,10 +4708,6 @@ public class MyFeignClient {
             Solution: HttpClients should disable connection state tracking in order to reuse TLS connections, since service calls for one pool have the same user identity/security context for all sessions. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (:locally created http client builder without disableConnectionState :)
@@ -4974,6 +4722,7 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 			]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -4985,8 +4734,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Either use 1. setConnectionManager and call setMaxTotal and setDefaultMaxPerRoute on that connection manager, or 2. no ConnectionManager: call setMaxConnTotal and setMaxConnPerRoute on the client directly. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder without setMaxConnTotal/setMaxConnPerRoute :)
@@ -5027,6 +4774,7 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5053,10 +4801,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Solution: Set the timeouts explicitly to proper reasoned values. See best practice values via the link. Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts.(jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: only for Apache http client 4 :)
@@ -5121,6 +4865,7 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
+            <property name="tags" value="io,jpinpoint-rule,performance,pitfall" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5146,10 +4891,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Solution: Set connectTimeout and connectionRequestTimeout to values based om tests, for instance 200 ms and 250 ms. respectively (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: use of field, local var and return statement :)
@@ -5177,6 +4918,7 @@ ancestor::ClassOrInterfaceDeclaration[//LocalVariableDeclaration/Type
 ]]>
                 </value>
             </property>
+            <property name="tags" value="io,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5207,10 +4949,6 @@ public class HttpClientStuff {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[not (Annotation//Name[@Image='PostConstruct'])]
@@ -5218,6 +4956,7 @@ public class HttpClientStuff {
  /PrimaryExpression/PrimaryPrefix/Name[@Image = 'JAXBContext.newInstance']
                 ]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5227,10 +4966,6 @@ public class HttpClientStuff {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -5247,6 +4982,7 @@ public class HttpClientStuff {
 ]/VariableInitializer//PrimaryPrefix/Name[ends-with(@Image, 'build')]
 			]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
          </properties>
         <example>
             <![CDATA[
@@ -5269,12 +5005,6 @@ public static JsonMapper createMapper() {
             Solution: Have the retry mechanism in one location in the chain only, recommended only the one closest to the user. (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="resilience" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Retry']
@@ -5285,6 +5015,7 @@ public static JsonMapper createMapper() {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,resilience,suspicious,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5310,11 +5041,6 @@ public class Foo {
             Note that the pool will only grow beyond CorePoolSize up to MaxPoolSize when the queue is full. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //LocalVariableDeclaration//AllocationExpression/ClassOrInterfaceType[@Image='ThreadPoolTaskExecutor']
@@ -5323,6 +5049,7 @@ public class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5353,8 +5080,6 @@ public class Foo {
             Solution: Use ClosableHttpClient to allow for invoking close on it to properly close the connection. Or use HttpComponentsClientHttpRequestFactory(httpClient) to let it manage closing. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: bad: HttpClient without HttpComponentsClientHttpRequestFactory :)
@@ -5371,6 +5096,7 @@ public class Foo {
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
         <![CDATA[
@@ -5400,15 +5126,12 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']/MemberValuePairs/MemberValuePair[@MemberName='key']
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5431,11 +5154,6 @@ class Bad1 {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImplementsList/ClassOrInterfaceType[pmd-java:typeIs("org.springframework.cache.interceptor.KeyGenerator")]
@@ -5453,6 +5171,7 @@ ForStatement[./Expression//Name[@Image = ancestor::MethodDeclaration//FormalPara
 )
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5495,10 +5214,6 @@ public class Good implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5515,6 +5230,7 @@ exists(./Annotation//Name[@Image='Component' or @Image='Service' or @Image='Cont
                     ]]>
                 </value>
             </property>
+            <property name="tags" value="confusing,data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5537,10 +5253,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -5551,6 +5263,7 @@ MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Annotation/M
 Annotation//Name[@Image='RenderMapping'])]
 	]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5561,14 +5274,12 @@ Annotation//Name[@Image='RenderMapping'])]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.support.SimpleCacheManager') or pmd-java:typeIs('org.springframework.cache.concurrent.ConcurrentMapCache')]
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5600,9 +5311,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.interceptor.KeyGenerator')]]
@@ -5622,6 +5330,7 @@ class Good {
 ]/../Arguments
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,data-mix-up,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5656,10 +5365,6 @@ class GoodCacheKeyGenerator implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5671,6 +5376,7 @@ and (
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5685,10 +5391,6 @@ and (
             redirect:/redirectUrl?someAttribute={someAttribute}.(jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (
@@ -5719,6 +5421,7 @@ and (
 )
             ]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5733,9 +5436,6 @@ and (
             (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[.//NormalAnnotation/Name[@Image='Cacheable']]
@@ -5749,6 +5449,7 @@ and (
   ]
 	]]></value>
             </property>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5788,8 +5489,6 @@ class MyObject {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5808,6 +5507,7 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5818,10 +5518,6 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -5832,6 +5528,7 @@ Annotation//Name[@Image='ActionMapping']) and
 count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
 	]]></value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -5842,11 +5539,6 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']
@@ -5854,6 +5546,7 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
 //ClassOrInterfaceBodyDeclaration//Annotation/MarkerAnnotation[Name/@Image='Cacheable'])[count(MemberValuePairs/MemberValuePair[@MemberName='sync']) = 0]
 	]]></value>
             </property>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5881,16 +5574,13 @@ class Good1 {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[@SimpleName = 'CacheKeyGenerator' and @Interface = false() and @Abstract = false()]
 /ImplementsList/ClassOrInterfaceType[@Image='KeyGenerator']
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,confusing,data-mix-up,jpinpoint-rule" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5914,15 +5604,13 @@ public class CacheKeyGenerator implements KeyGenerator { // bad, unclear name
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Cacheable']
 /../MemberValuePairs[count(MemberValuePair[@Image='keyGenerator']) = 0]
 	]]></value>
             </property>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -5955,12 +5643,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5977,6 +5659,7 @@ concat(ancestor::MethodDeclaration//VariableDeclarator[./VariableInitializer//Na
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,io,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[
@@ -6001,10 +5684,6 @@ concat(ancestor::MethodDeclaration//VariableDeclarator[./VariableInitializer//Na
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -6018,6 +5697,7 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -6031,11 +5711,6 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -6048,6 +5723,7 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
 ]]>
                 </value>
             </property>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
         </properties>
     </rule>
 
@@ -6061,8 +5737,6 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -6092,6 +5766,7 @@ ancestor::BlockStatement//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,
 ]]>
                 </value>
             </property>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
         </properties>
         <example>
             <![CDATA[

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -24,7 +24,8 @@
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Expression/PrimaryExpression/PrimaryPrefix/Name[@Image='CDI.current']/../../
@@ -82,7 +83,8 @@ public class CDIStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //(Type)[pmd-java:typeIs('java.util.Calendar')]
@@ -119,7 +121,6 @@ public class CalendarStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
  //ClassOrInterfaceDeclaration[@Interface=true()]/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
@@ -148,7 +149,6 @@ public interface Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/VariableDeclarator/VariableInitializer/Expression[pmd-java:typeIs('java.text.DecimalFormat') or pmd-java:typeIs('java.text.ChoiceFormat')]
@@ -169,7 +169,6 @@ public interface Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -205,7 +204,6 @@ or preceding-sibling::SwitchLabel[@Default=true()])
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //RecordDeclaration//RecordComponent/Type[(pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map'))
@@ -238,7 +236,8 @@ record GoodRecord(String name, List<String> list) {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//MethodDeclaration//(PrimaryPrefix/Name[ends-with(@Image, '.replaceAll') or ends-with(@Image, '.replaceFirst') or @Image='Pattern.matches']
@@ -333,7 +332,8 @@ String good_replaceInnerLineBreakBySpace() {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.ByteArrayOutputStream') or pmd-java:typeIs('java.io.StringWriter')]
@@ -382,7 +382,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[@Image='Files.readAllBytes' or @Image='Files.readAllLines']
@@ -425,7 +426,6 @@ class Good {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="unused" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //(TypeDeclaration|ClassOrInterfaceBodyDeclaration/ClassOrInterfaceDeclaration/..)/Annotation
@@ -453,7 +453,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block[
@@ -493,7 +494,6 @@ and
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
     (: a field of type List :)
@@ -566,7 +566,8 @@ public class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //EnumDeclaration/EnumBody[count(EnumConstant) > 3]//MethodDeclaration/Block//PrimaryExpression
@@ -626,7 +627,8 @@ public enum Fruit {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -672,7 +674,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration//ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -732,7 +735,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -769,7 +773,9 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[not((@Name='main' and @Static=true())or ../Annotation//Name/@Image='PostConstruct'
@@ -813,7 +819,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/AllocationExpression/ClassOrInterfaceType
@@ -846,7 +853,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[
@@ -870,7 +878,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
                     //VariableDeclarator[../Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.StringBuffer')]]
@@ -888,7 +897,6 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -926,7 +934,6 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -964,7 +971,8 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement/Statement//StatementExpression/PrimaryExpression/PrimaryPrefix/Name[
@@ -1003,7 +1011,6 @@ substring-after(@Image, '.') != 'append')]) = 0
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: append used in one chained statement on allocated StringBuilder and with chained toString :)
@@ -1062,7 +1069,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -1086,7 +1094,8 @@ and
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
@@ -1105,7 +1114,8 @@ and
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/
@@ -1132,7 +1142,9 @@ ClassOrInterfaceBodyDeclaration
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Resource//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.FileInputStream') or pmd-java:typeIs('java.io.FileOutputStream')]
@@ -1176,7 +1188,9 @@ class BufferFileStreaming {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[pmd-java:typeIs('java.nio.file.Files') and ends-with(@Image,'.newOutputStream')]
@@ -1211,7 +1225,6 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1308,7 +1321,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1371,7 +1383,6 @@ class Bad {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[@Name='equals' and MethodDeclarator/FormalParameters/@Size=1 and @Public=true() and @Static=false()]
@@ -1426,7 +1437,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -1550,7 +1560,6 @@ class LombokGetterGood {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //VariableDeclaratorId[matches(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN', 'i')
@@ -1584,7 +1593,6 @@ class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -1634,7 +1642,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration/MethodDeclaration[../..//(VariableDeclaratorId |ReturnStatement/Expression)[pmd-java:typeIs('javax.portlet.PortletSession') or pmd-java:typeIs('javax.servlet.http.HttpSession')]]
@@ -1690,7 +1699,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration[@Static=false()]//VariableDeclaratorId[
@@ -1747,7 +1755,6 @@ class Bad1 {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1813,7 +1820,8 @@ class Bad {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: check key/elem type in declaration :)
@@ -1875,7 +1883,8 @@ and (pmd-java:typeIs('java.lang.Object'))
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/Type[pmd-java:typeIs('java.util.Set') and ReferenceType//TypeArgument[1][not(pmd-java:typeIs('java.lang.Comparable'))
@@ -1944,7 +1953,9 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/ReferenceType/ClassOrInterfaceType
@@ -2008,7 +2019,8 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name[ends-with(@Image,'.trace') or ends-with(@Image,'.debug') or
@@ -2051,7 +2063,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name
@@ -2116,7 +2129,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
           //PrimaryPrefix/Name
@@ -2184,7 +2198,6 @@ class Foo {
                       description="Regex for inclusion of rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
                       description="Regex for exclusion of rules"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image="SuppressWarnings" or @Image="SuppressFBWarnings"]/..//Literal[(matches(@Image, $ruleIdMatches)) and not (matches(@Image, $ruleIdNotMatches))]
@@ -2207,7 +2220,6 @@ class Foo {
                       description="Regex for inclusion of high risk rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
                       description="Regex for exclusion of high risk rules"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image="SuppressWarnings" or @Image="SuppressFBWarnings"]/..//Literal[(matches(@Image, $ruleIdMatches)) and not (matches(@Image, $ruleIdNotMatches))]
@@ -2233,7 +2245,9 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2285,7 +2299,9 @@ public class FileStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
@@ -2333,7 +2349,8 @@ public class DateStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement[
@@ -2383,7 +2400,8 @@ public class StringStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ForStatement | //WhileStatement | //DoStatement)//AssignmentOperator[
@@ -2437,7 +2455,6 @@ public class StringStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression[(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'forEach')]]
@@ -2483,7 +2500,6 @@ public class StringStuff {
             <property name="tag" value="unused" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for each assignment node :)
@@ -2544,7 +2560,6 @@ return ($node[
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[@Image='Serializable']
@@ -2609,7 +2624,6 @@ class Baz extends RemoteException {
             <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-block-max" value="1" type="String" description="Maximum allowed depth of lambda-with-code-block nesting"/>
             <property name="param-single-max" value="4" type="String" description="Maximum allowed depth of lambda-single-expression nesting"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //LambdaExpression[Block][count(ancestor::LambdaExpression/Block) > number($param-block-max)]
@@ -2660,7 +2674,6 @@ class Foo {
             <property name="tag" value="brain-overload" type="String" description="for-sonar"/>
             <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="5" type="String" description="Maximum number of allowed non-setter statements"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //LambdaExpression/Block
@@ -2718,7 +2731,6 @@ class Foo {
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="3" type="String" description="Maximum number of allowed static imports with wildcard"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImportDeclaration[@Static=true() and @ImportOnDemand=true()][position() > number($param-max)]
@@ -2760,8 +2772,7 @@ import static com.co.corporate.Constants.GREAT; // good
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-	    <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: assumption: if import of web client / http client is present, parallelStreaming is for remote calls :)
@@ -2829,8 +2840,8 @@ public class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-	    <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
+	        <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2876,7 +2887,7 @@ public class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2915,7 +2926,7 @@ public class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression[PrimarySuffix[@ArgumentCount=1]]/PrimaryPrefix
@@ -2953,7 +2964,6 @@ class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3021,7 +3031,7 @@ class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3089,7 +3099,6 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/(AssignmentOperator[@Image='+=' or @Image='-=']/..|
@@ -3138,7 +3147,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[@Image='MDC.setContextMap' and
@@ -3190,7 +3200,6 @@ class FooGood {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3258,7 +3267,6 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3307,7 +3315,8 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimarySuffix[@Image='parallel' and ../PrimaryPrefix/Name[@Image = 'Flux.fromIterable']
@@ -3352,9 +3361,10 @@ class FooGood {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="performance" type="String" description="for-sonar"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/(PrimarySuffix[@Image='parallelStream' or @Image='parallel']|PrimaryPrefix/Name[ends-with(@Image, '.parallelStream') or ends-with(@Image, '.parallel')])
@@ -3427,7 +3437,8 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix/Name[@Image='Hooks.onEachOperator']
@@ -3455,13 +3466,12 @@ public class FooBad {
     <rule name="AvoidStaticXmlFactories" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java" message="Avoid static XML Factories" typeResolution="true"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#IUOXAR09">
         <description>An XML Factory like DocumentBuilderFactory, TransformerFactory, MessageFactory is used as static field. Problem: These factory objects are typically not thread-safe and rather expensive to create because of class loading. &#13;
-            Solution: Create the Factories as local variables and use command line arguments to specify the implementation class. (jpinpoint-rules)</description>
+            Solution: Use thread locals or create the Factories as local variables and anyway use properties to specify the implementation class. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBodyDeclaration//FieldDeclaration[@Static=true() and (
@@ -3503,7 +3513,6 @@ public class FooBad {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[pmd-java:typeIs('javax.xml.bind.Marshaller')
@@ -3530,7 +3539,6 @@ public class FooBad {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3570,7 +3578,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3627,7 +3634,6 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3678,7 +3684,6 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3738,7 +3743,6 @@ and not (../Annotation//Name[@Image='GuardedBy'])
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3788,7 +3792,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
 	        <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/Annotation//Name[(@Image='Component' or @Image='Service' or @Image='Controller' or @Image='RestController' or @Image='Repository' or
@@ -3855,7 +3858,6 @@ public class VMRData {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
     //FieldDeclaration[@Volatile = true() and
@@ -3895,7 +3897,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -3973,7 +3974,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -4019,8 +4019,9 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-	    <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+	        <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: var.x() in synchronized block, var in list of local vars and all var.x in synchronized block are local vars:)
@@ -4083,7 +4084,8 @@ public class Foo {
         <property name="tag" value="confusing" type="String" description="for-sonar"/>
         <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
         <property name="tag" value="performance" type="String" description="for-sonar"/>
-        <property name="version" value="2.0"/>
+        <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+        <property name="tag" value="cpu" type="String" description="for-sonar"/>
         <property name="xpath">
             <value>
                 <![CDATA[
@@ -4142,7 +4144,6 @@ class SingletonGood {
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[@Image='ClientHttpRequestFactorySupplier']
@@ -4199,7 +4200,6 @@ and use it to replace the bad line in Bad example:
         <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
         <property name="tag" value="deprecated" type="String" description="for-sonar"/>
         <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-        <property name="version" value="2.0"/>
         <property name="xpath">
             <value><![CDATA[
 //ImportDeclaration/Name[@Image='org.apache.commons.httpclient.SimpleHttpConnectionManager'
@@ -4253,7 +4253,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="deprecated" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImportDeclaration/Name[starts-with(@Image, "com.netflix.hystrix")]
@@ -4276,7 +4275,6 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //Statement[StatementExpression[//ArgumentList]/PrimaryExpression/PrimaryPrefix/Name/@Image =
@@ -4325,7 +4323,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Type//ClassOrInterfaceType[@Image='SaajSoapMessageFactory'
@@ -4373,7 +4372,6 @@ class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/@TypeImage='int']/VariableDeclarator[VariableDeclaratorId[@Final = true()][contains(upper-case(@Name), 'TIMEOUT') or contains(upper-case(@Name), 'DURATIONOUT')
@@ -4423,7 +4421,6 @@ class AvoidHardcodedConnectionConfig {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression[pmd-java:typeIs("org.apache.http.HttpHost")]/Arguments/ArgumentList[count(./Expression) = 1]/../..
@@ -4454,14 +4451,15 @@ class Foo {
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           typeResolution="true"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#iuoxar04">
-        <description>Problem: JAXB utility methods do not reuse JAXBContext when more that one context is used. &#13;
+        <description>Problem: JAXB utility methods do not reuse JAXBContext when more than one context is used. &#13;
             Solution: use JAXB API directly for marshalling and unmarshalling to gain all the performance benefits as described in IUOXAR04 and IUOXAR06.
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('javax.xml.bind.JAXB')]
@@ -4497,7 +4495,8 @@ public class XMLConversion {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[pmd-java:typeIs('io.github.resilience4j.retry.Retry') and ends-with(@Image, '.getEventPublisher')]
@@ -4546,7 +4545,6 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: exclude method annotated with PostConstruct :)
@@ -4612,7 +4610,6 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (for $node in (//FieldDeclaration[pmd-java:typeIs('com.fasterxml.jackson.databind.ObjectMapper')
@@ -4655,7 +4652,8 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('reactor.core.publisher.Hooks')]//Name[ends-with(@Image, 'Hooks.onOperatorDebug')]
@@ -4685,7 +4683,8 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
    //TypeDeclaration/ClassOrInterfaceDeclaration[count(.//Annotation//Name[@Image='Configuration']) = 0]
@@ -4719,8 +4718,8 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/
@@ -4747,7 +4746,8 @@ MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceT
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//VariableDeclarator[pmd-java:typeIs('io.axual.client.producer.Producer')]
@@ -4792,7 +4792,9 @@ class AxualProducerGood2{
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: somehow typeIs does not work with spring-web-6.0, do it old school way :)
@@ -4831,7 +4833,8 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: default client constructor with sslSocketFactory :)
@@ -4874,7 +4877,8 @@ public class MyFeignClient {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -4901,7 +4905,6 @@ public class MyFeignClient {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="correctness" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder with setConnectionManager and at least one of setMaxConnTotal/setMaxConnPerRoute :)
@@ -4955,7 +4958,8 @@ public class MyFeignClient {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (:locally created http client builder without disableConnectionState :)
@@ -4983,7 +4987,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder without setMaxConnTotal/setMaxConnPerRoute :)
@@ -5052,8 +5055,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: only for Apache http client 4 :)
@@ -5145,7 +5148,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: use of field, local var and return statement :)
@@ -5205,7 +5209,8 @@ public class HttpClientStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[not (Annotation//Name[@Image='PostConstruct'])]
@@ -5224,7 +5229,8 @@ public class HttpClientStuff {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -5267,7 +5273,8 @@ public static JsonMapper createMapper() {
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="resilience" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Retry']
@@ -5305,8 +5312,9 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //LocalVariableDeclaration//AllocationExpression/ClassOrInterfaceType[@Image='ThreadPoolTaskExecutor']
@@ -5347,7 +5355,6 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 (: bad: HttpClient without HttpComponentsClientHttpRequestFactory :)
@@ -5395,7 +5402,8 @@ public class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']/MemberValuePairs/MemberValuePair[@MemberName='key']
@@ -5425,8 +5433,9 @@ class Bad1 {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImplementsList/ClassOrInterfaceType[pmd-java:typeIs("org.springframework.cache.interceptor.KeyGenerator")]
@@ -5490,7 +5499,6 @@ public class Good implements KeyGenerator {
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5531,7 +5539,8 @@ class Good {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -5547,7 +5556,7 @@ Annotation//Name[@Image='RenderMapping'])]
 
     <rule name="AvoidSimpleCaches" class="net.sourceforge.pmd.lang.rule.XPathRule" dfa="false" language="java" message="Avoid simple caching in production" typeResolution="true"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/master/docs/JavaCodePerformance.md#ic08">
-        <description>Simple caches are used. Problem: Simple caching is meant for testing and prototyping and it lacks manageability and monitorability.&#13;
+        <description>Simple caches are used. Problem: Simple caching is meant for testing and prototyping, and it lacks manageability and monitorability.&#13;
             Solution: Use a proper cache implementation like ehcache or a cloud cache.
             (jpinpoint-rules)</description>
         <priority>2</priority>
@@ -5555,7 +5564,6 @@ Annotation//Name[@Image='RenderMapping'])]
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
     //AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.support.SimpleCacheManager') or pmd-java:typeIs('org.springframework.cache.concurrent.ConcurrentMapCache')]
@@ -5593,10 +5601,8 @@ class Good {
         <priority>2</priority>
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.interceptor.KeyGenerator')]]
@@ -5652,7 +5658,8 @@ class GoodCacheKeyGenerator implements KeyGenerator {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5680,7 +5687,8 @@ and (
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (
@@ -5726,10 +5734,8 @@ and (
         <priority>5</priority>
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[.//NormalAnnotation/Name[@Image='Cacheable']]
@@ -5784,7 +5790,6 @@ class MyObject {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5815,7 +5820,8 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -5839,7 +5845,8 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']
@@ -5878,7 +5885,6 @@ class Good1 {
             <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[@SimpleName = 'CacheKeyGenerator' and @Interface = false() and @Abstract = false()]
@@ -5911,7 +5917,6 @@ public class CacheKeyGenerator implements KeyGenerator { // bad, unclear name
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Cacheable']
@@ -5952,7 +5957,10 @@ class Foo {
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -5995,7 +6003,8 @@ concat(ancestor::MethodDeclaration//VariableDeclarator[./VariableInitializer//Na
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -6024,7 +6033,9 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
+            <property name="tag" value="cpu" type="String" description="for-sonar"/>
+            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -6052,7 +6063,6 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
         <properties>
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
                     <![CDATA[

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -42,7 +42,8 @@ PrimarySuffix[@Image = 'select']/ancestor::VariableDeclarator/VariableDeclarator
 ])]
 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -85,7 +86,8 @@ public class CDIStuff {
 //Name[starts-with(@Image, 'Calendar.')]
 	         ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -118,7 +120,8 @@ public class CalendarStuff {
  //ClassOrInterfaceDeclaration[@Interface=true()]/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -145,7 +148,8 @@ public interface Foo {
 //FieldDeclaration/VariableDeclarator/VariableInitializer/Expression[pmd-java:typeIs('java.text.DecimalFormat') or pmd-java:typeIs('java.text.ChoiceFormat')]
         ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -178,7 +182,8 @@ or preceding-sibling::SwitchLabel[@Default=true()])
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -200,7 +205,8 @@ and
 not(../VariableDeclaratorId/@Name = ancestor::RecordDeclaration/RecordBody/CompactConstructorDeclaration//StatementExpression
 [Expression//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'copyOf')]]/PrimaryExpression/PrimaryPrefix/Name/@Image)]                ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -290,7 +296,8 @@ VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Literal[string-le
 ]])
 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -328,7 +335,8 @@ or
 ]/..
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -369,7 +377,8 @@ class Good {
 //MethodDeclaration//PrimaryPrefix/Name[@Image='Files.readAllBytes' or @Image='Files.readAllLines']
                 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -411,7 +420,8 @@ class Good {
     [count(..//FieldDeclaration) = 0]
                 ]]></value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule,unused" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,unused" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -453,7 +463,8 @@ and
 ]) > 1 ]//BlockStatement[position()=last()]//StatementExpression/Expression/AdditiveExpression[@Operator = '+']
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -502,7 +513,8 @@ not(@Name = ancestor::ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/Metho
     )]
 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -547,7 +559,8 @@ public class Good {
     [PrimarySuffix[starts-with(@Image, 'find')]]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -607,7 +620,8 @@ and not (
 ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Name)]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -650,7 +664,8 @@ class Good {
 or (pmd-java:typeIs('javax.xml.xpath.XPath') and ends-with(@Image, 'evaluate'))]
 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -719,7 +734,8 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
                    ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -742,7 +758,8 @@ or .//IfStatement//EqualityExpression[@Operator='=='][
 //AllocationExpression[pmd-java:typeIs('java.security.Provider')]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -796,7 +813,8 @@ class Foo {
 	]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -819,7 +837,8 @@ class Foo {
 ]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -834,7 +853,8 @@ class Foo {
                     //VariableDeclarator[../Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.StringBuffer')]]
                     ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -860,7 +880,8 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -896,7 +917,8 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -938,7 +960,8 @@ substring-after(@Image, '.') != 'append')]) = 0
 ]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -980,7 +1003,8 @@ and not(substring-before(@Image, '.') = ancestor::Block//Statement//PrimarySuffi
 ]
 	         ]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1022,7 +1046,8 @@ and
 ]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -1039,7 +1064,8 @@ and
 //PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'XPathAPI.')]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -1058,7 +1084,8 @@ ClassOrInterfaceBodyDeclaration
 [not (ancestor::FieldDeclaration//ClassOrInterfaceType/@Image = 'ThreadLocal')]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -1082,7 +1109,8 @@ ClassOrInterfaceBodyDeclaration
 [not (ancestor::TryStatement//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.BufferedInputStream') or pmd-java:typeIs('BufferedOutputStream')])]
 ]]></value>
             </property>
-            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1128,7 +1156,8 @@ and (not(.//PrimaryPrefix/Name[pmd-java:typeIs('org.apache.commons.io.IOUtils') 
 ]]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1169,7 +1198,8 @@ class Foo {
                 ]]>
                 </value>
             </property>
-            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1256,7 +1286,8 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
-            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1313,7 +1344,8 @@ class Bad {
 /Block[count(./BlockStatement/Statement) = 1][count(.//ArgumentList) = 0]//PrimaryExpression[PrimaryPrefix[@SuperModifier=true()]]/PrimarySuffix[@Image='hashCode']
                 ]]></value>
             </property>
-            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1437,7 +1469,8 @@ ancestor::ClassOrInterfaceBodyDeclaration[1]/Annotation//Name[@Image='Getter']
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,unpredictable" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1487,7 +1520,8 @@ and replace(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN|_', ''
 or starts-with(@Name, 'var') and number(substring-after(@Name, 'var'))]
                 ]]></value>
             </property>
-            <property name="tags" value="bad-practice,confusing,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1523,7 +1557,8 @@ and not((ancestor::MethodDeclaration//TryStatement/FinallyStatement//StatementEx
 ]]>
                 </value>
             </property>
-            <property name="tags" value="correctness,jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1576,7 +1611,8 @@ ClassOrInterfaceBodyDeclaration//MethodDeclaration/Block//PrimaryExpression/Prim
 )]]
 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1634,7 +1670,8 @@ class Good {
 			]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1679,7 +1716,8 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1752,7 +1790,8 @@ and (pmd-java:typeIs('java.lang.Object'))
 ]
                ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1815,7 +1854,8 @@ or ancestor::MethodDeclaration//PrimaryExpression/PrimaryPrefix/Name/@Image = co
 ]/../..
                ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1905,7 +1945,8 @@ VariableDeclarator/VariableInitializer/Expression
 /TypeArguments/TypeArgument[1]/ReferenceType[pmd-java:typeIs('java.lang.Enum') or ClassOrInterfaceType/@Image = //EnumDeclaration/@SimpleName]]/VariableDeclarator/VariableDeclaratorId/@Name]
 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1934,7 +1975,8 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
     ])]
 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
         <![CDATA[
@@ -2001,7 +2043,8 @@ class Foo {
 ]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2066,7 +2109,8 @@ class Foo {
 			]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2097,7 +2141,8 @@ class Foo {
 			]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -2117,7 +2162,8 @@ class Foo {
 			]]>
                 </value>
             </property>
-            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -2157,7 +2203,8 @@ class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="io,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2195,7 +2242,8 @@ PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'
 //ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
 	         ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2247,7 +2295,8 @@ ancestor::Block//LocalVariableDeclaration[@Final=true()]//VariableDeclaratorId/@
 ]]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2293,7 +2342,8 @@ public class StringStuff {
 	]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2340,7 +2390,8 @@ public class StringStuff {
 )]
                 ]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2410,7 +2461,8 @@ return ($node[
 )
                 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,replaces-sonar-rule,suspicious,unused" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,replaces-sonar-rule,suspicious,unused" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2450,7 +2502,8 @@ and (pmd-java:typeIs('java.lang.Object'))]))
 ]
                 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2500,7 +2553,8 @@ class Baz extends RemoteException {
 //LambdaExpression[Expression][count(ancestor::LambdaExpression) > number($param-single-max)]
                 ]]></value>
             </property>
-            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2549,7 +2603,8 @@ class Foo {
 ]
                 ]]></value>
             </property>
-            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2601,7 +2656,8 @@ class Foo {
 	]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2646,7 +2702,8 @@ and not(ancestor::Block//StatementExpression/PrimaryExpression/PrimaryPrefix/Nam
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2709,7 +2766,8 @@ public class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall,unpredictable" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2763,7 +2821,8 @@ public class Foo {
 ]    ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -2785,7 +2844,8 @@ public class Foo {
 /../PrimarySuffix//ArgumentList
                 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2853,7 +2913,8 @@ class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2908,7 +2969,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2952,7 +3014,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
                         ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2997,7 +3060,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 or ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter[pmd-java:typeIs('reactor.util.context.Context')])]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3074,7 +3138,8 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3132,7 +3197,8 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3157,7 +3223,8 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
 and //ImportDeclaration/Name[starts-with(@Image, 'reactor.core.publisher')]]
                 ]]></value>
             </property>
-            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3204,7 +3271,8 @@ class FooGood {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low,unpredictable" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3270,7 +3338,8 @@ public class Foo {
 //StatementExpression/PrimaryExpression/PrimaryPrefix/Name[@Image='Hooks.onEachOperator']
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3312,7 +3381,8 @@ public class FooBad {
 			]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3344,7 +3414,8 @@ public class FooBad {
  or pmd-java:typeIs('javax.xml.validation.Validator')]
 			]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3379,7 +3450,8 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3433,7 +3505,8 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
 ]]>
                 </value>
             </property>
-            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3481,7 +3554,8 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3538,7 +3612,8 @@ and not (../Annotation//Name[@Image='GuardedBy'])
 ]]>
                 </value>
             </property>
-            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3591,7 +3666,8 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
                     ]]>
                 </value>
             </property>
-            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -3618,7 +3694,8 @@ and not ((ancestor::TypeDeclaration/Annotation//Name[@Image='ConfigurationProper
 ]]>
                 </value>
             </property>
-            <property name="tags" value="correctness,data-mix-up,jpinpoint-rule,multi-threading,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,data-mix-up,jpinpoint-rule,multi-threading,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3675,7 +3752,8 @@ public class VMRData {
                         ]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3741,7 +3819,8 @@ class Good {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3795,7 +3874,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3838,7 +3918,8 @@ count(distinct-values(ancestor::MethodDeclaration//LocalVariableDeclaration//Var
                         ]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -3894,7 +3975,8 @@ and (count(ancestor::TypeDeclaration//MethodDeclaration[@Public=true() and not(e
                 ]]>
             </value>
         </property>
-            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
     </properties>
     <example>
         <![CDATA[
@@ -3944,7 +4026,8 @@ class SingletonGood {
 [/CompilationUnit/ImportDeclaration/Name[starts-with(@Image, 'org.springframework.boot.web.client')]]]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule,performance,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,performance,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4019,7 +4102,8 @@ or pmd-java:typeIs('org.apache.commons.httpclient.MultiThreadedHttpConnectionMan
 ]
 		     ]]></value>
         </property>
-            <property name="tags" value="data-mix-up,deprecated,jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,deprecated,jpinpoint-rule,multi-threading" type="String" description="classification"/>
     </properties>
         <example>
             <![CDATA[
@@ -4049,7 +4133,8 @@ class Good {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="deprecated,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="deprecated,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
         </example>
@@ -4072,7 +4157,8 @@ ancestor::MethodDeclaration//VariableDeclarator[.//AllocationExpression/ClassOrI
 ]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4120,7 +4206,8 @@ and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[
 and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[@Image='System.setProperty'] and ./PrimarySuffix/Arguments//Literal[@Image='"javax.xml.transform.TransformerFactory"']])]
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4163,7 +4250,8 @@ or(contains(upper-case(@Name), 'MAX') and contains(upper-case(@Name), 'ROUTE'))]
 [VariableInitializer//Literal or VariableDeclaratorId/@Name=ancestor::ClassOrInterfaceBody//ConstructorDeclaration//StatementExpression[Expression//Literal]//Name/@Image]
                 ]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4209,7 +4297,8 @@ class AvoidHardcodedConnectionConfig {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4244,7 +4333,8 @@ class Foo {
 //PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('javax.xml.bind.JAXB')]
 	         ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4283,7 +4373,8 @@ public class XMLConversion {
 /VariableDeclarator/VariableDeclaratorId/@Name), substring-before(@Image,'.')))]
                 ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4345,7 +4436,8 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4400,7 +4492,8 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4431,7 +4524,8 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4462,7 +4556,8 @@ public class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4494,7 +4589,8 @@ FieldDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.
 MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.xml.datatype.XMLGregorianCalendar')]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -4516,7 +4612,8 @@ MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceT
 [ancestor::TypeDeclaration[count(./Annotation//Name[@Image='Configuration'])=0]]
 			]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4561,7 +4658,8 @@ class AxualProducerGood2{
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4598,7 +4696,8 @@ and not(ancestor::Expression//Arguments[ArgumentList/@Size=2]//Expression[1]//Nu
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4644,7 +4743,8 @@ public class MyFeignClient {
 ]
 			]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -4680,7 +4780,8 @@ public class MyFeignClient {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4722,7 +4823,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 			]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -4774,7 +4876,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4865,7 +4968,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
-            <property name="tags" value="io,jpinpoint-rule,performance,pitfall" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4918,7 +5022,8 @@ ancestor::ClassOrInterfaceDeclaration[//LocalVariableDeclaration/Type
 ]]>
                 </value>
             </property>
-            <property name="tags" value="io,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -4956,7 +5061,8 @@ public class HttpClientStuff {
  /PrimaryExpression/PrimaryPrefix/Name[@Image = 'JAXBContext.newInstance']
                 ]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -4982,7 +5088,8 @@ public class HttpClientStuff {
 ]/VariableInitializer//PrimaryPrefix/Name[ends-with(@Image, 'build')]
 			]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
          </properties>
         <example>
             <![CDATA[
@@ -5015,7 +5122,8 @@ public static JsonMapper createMapper() {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,resilience,suspicious,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,resilience,suspicious,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5049,7 +5157,8 @@ public class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5096,7 +5205,8 @@ public class Foo {
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
         <![CDATA[
@@ -5131,7 +5241,8 @@ public class Foo {
 //ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']/MemberValuePairs/MemberValuePair[@MemberName='key']
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5171,7 +5282,8 @@ ForStatement[./Expression//Name[@Image = ancestor::MethodDeclaration//FormalPara
 )
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5230,7 +5342,8 @@ exists(./Annotation//Name[@Image='Component' or @Image='Service' or @Image='Cont
                     ]]>
                 </value>
             </property>
-            <property name="tags" value="confusing,data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5263,7 +5376,8 @@ MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Annotation/M
 Annotation//Name[@Image='RenderMapping'])]
 	]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5279,7 +5393,8 @@ Annotation//Name[@Image='RenderMapping'])]
     //AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.support.SimpleCacheManager') or pmd-java:typeIs('org.springframework.cache.concurrent.ConcurrentMapCache')]
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5330,7 +5445,8 @@ class Good {
 ]/../Arguments
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,data-mix-up,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5376,7 +5492,8 @@ and (
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5421,7 +5538,8 @@ and (
 )
             ]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5449,7 +5567,8 @@ and (
   ]
 	]]></value>
             </property>
-            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5507,7 +5626,8 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5528,7 +5648,8 @@ Annotation//Name[@Image='ActionMapping']) and
 count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
 	]]></value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5546,7 +5667,8 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
 //ClassOrInterfaceBodyDeclaration//Annotation/MarkerAnnotation[Name/@Image='Cacheable'])[count(MemberValuePairs/MemberValuePair[@MemberName='sync']) = 0]
 	]]></value>
             </property>
-            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5580,7 +5702,8 @@ class Good1 {
 /ImplementsList/ClassOrInterfaceType[@Image='KeyGenerator']
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,confusing,data-mix-up,jpinpoint-rule" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,confusing,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5610,7 +5733,8 @@ public class CacheKeyGenerator implements KeyGenerator { // bad, unclear name
 /../MemberValuePairs[count(MemberValuePair[@Image='keyGenerator']) = 0]
 	]]></value>
             </property>
-            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5659,7 +5783,8 @@ concat(ancestor::MethodDeclaration//VariableDeclarator[./VariableInitializer//Na
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,io,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -5697,7 +5822,8 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5723,7 +5849,8 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
 ]]>
                 </value>
             </property>
-            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -5766,7 +5893,8 @@ ancestor::BlockStatement//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,
 ]]>
                 </value>
             </property>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification" />
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -13,10 +13,6 @@
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Expression/PrimaryExpression/PrimaryPrefix/Name[@Image='CDI.current']/../../
@@ -37,6 +33,8 @@ PrimarySuffix[@Image = 'select']/ancestor::VariableDeclarator/VariableDeclarator
 ])]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -68,13 +66,13 @@ public class CDIStuff {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
  //ClassOrInterfaceDeclaration[@Interface=true()]/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -96,13 +94,13 @@ public interface Foo {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/VariableDeclarator/VariableInitializer/Expression[pmd-java:typeIs('java.text.DecimalFormat') or pmd-java:typeIs('java.text.ChoiceFormat')]
         ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -116,8 +114,6 @@ public interface Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -137,6 +133,8 @@ or preceding-sibling::SwitchLabel[@Default=true()])
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -148,10 +146,6 @@ or preceding-sibling::SwitchLabel[@Default=true()])
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//MethodDeclaration//(PrimaryPrefix/Name[ends-with(@Image, '.replaceAll') or ends-with(@Image, '.replaceFirst') or @Image='Pattern.matches']
@@ -218,6 +212,8 @@ VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Literal[string-le
 ]])
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -244,10 +240,6 @@ String good_replaceInnerLineBreakBySpace() {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.ByteArrayOutputStream') or pmd-java:typeIs('java.io.StringWriter')]
@@ -259,6 +251,8 @@ or
 ]/..
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -287,10 +281,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block[
@@ -314,6 +304,8 @@ and
 ]) > 1 ]//BlockStatement[position()=last()]//StatementExpression/Expression/AdditiveExpression[@Operator = '+']
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -324,10 +316,6 @@ and
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -338,6 +326,8 @@ and not (
 ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId/@Name)]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -371,10 +361,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration//ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -384,6 +370,8 @@ class Good {
 or (pmd-java:typeIs('javax.xml.xpath.XPath') and ends-with(@Image, 'evaluate'))]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -432,10 +420,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -456,6 +440,8 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
                    ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -466,10 +452,6 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/AllocationExpression/ClassOrInterfaceType
@@ -490,6 +472,8 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
 	]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -500,10 +484,6 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[
@@ -516,6 +496,8 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
 ]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -525,15 +507,13 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             Solution: Replace StringBuffer by StringBuilder.  (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
                     //VariableDeclarator[../Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.StringBuffer')]]
                     ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -544,10 +524,6 @@ ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Va
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement/Statement//StatementExpression/PrimaryExpression/PrimaryPrefix/Name[
@@ -569,6 +545,8 @@ substring-after(@Image, '.') != 'append')]) = 0
 ]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -579,10 +557,6 @@ substring-after(@Image, '.') != 'append')]) = 0
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
@@ -594,6 +568,8 @@ and
 ]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -604,16 +580,14 @@ and
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
 //PrimaryExpression/PrimaryPrefix/Name[starts-with(@Image, 'XPathAPI.')]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -624,10 +598,6 @@ and
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/
@@ -636,6 +606,8 @@ ClassOrInterfaceBodyDeclaration
 [not (ancestor::FieldDeclaration//ClassOrInterfaceType/@Image = 'ThreadLocal')]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -650,8 +622,6 @@ ClassOrInterfaceBodyDeclaration
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -730,6 +700,8 @@ ancestor::ClassOrInterfaceBodyDeclaration[1]/Annotation//Name[@Image='Getter']
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -767,9 +739,6 @@ class LombokGetterGood {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -782,6 +751,8 @@ and not((ancestor::MethodDeclaration//TryStatement/FinallyStatement//StatementEx
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -817,10 +788,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration/MethodDeclaration[../..//(VariableDeclaratorId |ReturnStatement/Expression)[pmd-java:typeIs('javax.portlet.PortletSession') or pmd-java:typeIs('javax.servlet.http.HttpSession')]]
@@ -838,6 +805,8 @@ ClassOrInterfaceBodyDeclaration//MethodDeclaration/Block//PrimaryExpression/Prim
 )]]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -873,10 +842,6 @@ class Good {
             Solution: Use SLF4J formatting with {}-placeholders or log and format conditionally.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name[ends-with(@Image,'.trace') or ends-with(@Image,'.debug') or
@@ -890,6 +855,8 @@ class Good {
     ])]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
         <![CDATA[
@@ -912,10 +879,6 @@ class Foo {
             Solution: Execute the operation only conditionally and utilize SLF4J formatting with {}-placeholders.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
           //PrimaryPrefix/Name
@@ -957,6 +920,8 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -977,9 +942,6 @@ class Foo {
             Solution: Suppress warnings judiciously based on full knowledge and report reasons to suppress (false positives) to the rule maintainers so the rule can be fixed. (jpinpoint-rules)</description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="ruleIdMatches" type="String" value="AvoidUnguardedMutableFieldsInSharedObjects|AvoidUnguardedAssignmentToNonFinalFieldsInSharedObjects|AvoidMutableStaticFields|[^\w]ALL[^\w]|[^\w]all[^\w]|PMD[^\.]|pmd[^:]"
                       description="Regex for inclusion of high risk rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
@@ -990,6 +952,8 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -999,8 +963,6 @@ class Foo {
             Solution: Suppress warnings judiciously based on full knowledge and report reasons to suppress (false positives) to the rule maintainers so the rule can be fixed. (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="ruleIdMatches" type="String" value=".*"
                       description="Regex for inclusion of rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
@@ -1011,6 +973,8 @@ class Foo {
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -1021,8 +985,6 @@ class Foo {
             Solution: Specify the time unit in the identifier, like connectTimeoutMillis. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -1038,6 +1000,8 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1058,8 +1022,6 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
             Solution: Specify the time unit in the identifier, like connectTimeoutMillis. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -1075,6 +1037,8 @@ or ends-with(lower-case(@Image), 'timeout}"') or ends-with(lower-case(@Image), '
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1094,8 +1058,6 @@ public RetrieveCache(final @Value("${cache.expiryTimeMillis}") long timeToLiveMi
             Solution: When objects are equal, hashCode needs to be equal, too. Use the same fields in equals and hashCode. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1107,6 +1069,8 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1150,8 +1114,6 @@ class Bad {
             Solution: When objects are equal, hashCode needs to be equal, too. Use the same fields in equals and hashCode and use identical conversions like toUpperCase() in both when needed. Don't use equalsIgnoreCase. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1171,6 +1133,8 @@ class Bad {
                 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1247,8 +1211,6 @@ class Good {
             Solution: include the missing field in the equals and hashCode method. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration[@Static=false()]//VariableDeclaratorId[
@@ -1270,6 +1232,8 @@ class Good {
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1303,8 +1267,6 @@ class Bad1 {
             Solution: Use the same fields in hashCode as are used in equals. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration//VariableDeclaratorId[
@@ -1316,6 +1278,8 @@ concat(@Name, '.hashCode') = ancestor::ClassOrInterfaceBody[1]//MethodDeclaratio
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1365,10 +1329,6 @@ class Bad {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //(Type)[pmd-java:typeIs('java.util.Calendar')]
@@ -1376,6 +1336,8 @@ class Bad {
 //Name[starts-with(@Image, 'Calendar.')]
 	         ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1407,8 +1369,6 @@ public class CalendarStuff {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     (: a field of type List :)
@@ -1443,6 +1403,8 @@ not(@Name = ancestor::ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/Metho
     )]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1479,8 +1441,6 @@ public class Good {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: append used in one chained statement on allocated StringBuilder and with chained toString :)
@@ -1507,6 +1467,8 @@ and not(substring-before(@Image, '.') = ancestor::Block//Statement//PrimarySuffi
 ]
 	         ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1541,11 +1503,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/ReferenceType/ClassOrInterfaceType
@@ -1592,6 +1549,8 @@ VariableDeclarator/VariableInitializer/Expression
 /TypeArguments/TypeArgument[1]/ReferenceType[pmd-java:typeIs('java.lang.Enum') or ClassOrInterfaceType/@Image = //EnumDeclaration/@SimpleName]]/VariableDeclarator/VariableDeclaratorId/@Name]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1612,9 +1571,6 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
         </description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unused" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //(TypeDeclaration|ClassOrInterfaceBodyDeclaration/ClassOrInterfaceDeclaration/..)/Annotation
@@ -1622,6 +1578,8 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
     [count(..//FieldDeclaration) = 0]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,unused" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1644,10 +1602,6 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix/Name
@@ -1687,6 +1641,8 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
 ]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1715,9 +1671,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //VariableDeclaratorId[matches(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN', 'i')
@@ -1725,6 +1678,8 @@ and replace(@Name, 'ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN|_', ''
 or starts-with(@Name, 'var') and number(substring-after(@Name, 'var'))]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1753,8 +1708,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //RecordDeclaration//RecordComponent/Type[(pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map'))
@@ -1762,6 +1715,8 @@ and
 not(../VariableDeclaratorId/@Name = ancestor::RecordDeclaration/RecordBody/CompactConstructorDeclaration//StatementExpression
 [Expression//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'copyOf')]]/PrimaryExpression/PrimaryPrefix/Name/@Image)]                ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1789,10 +1744,6 @@ record GoodRecord(String name, List<String> list) {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //EnumDeclaration/EnumBody[count(EnumConstant) > 3]//MethodDeclaration/Block//PrimaryExpression
@@ -1801,6 +1752,8 @@ record GoodRecord(String name, List<String> list) {
     [PrimarySuffix[starts-with(@Image, 'find')]]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1857,10 +1810,6 @@ public enum Fruit {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: check key/elem type in declaration :)
@@ -1881,6 +1830,8 @@ and (pmd-java:typeIs('java.lang.Object'))
 ]
                ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1920,10 +1871,6 @@ and (pmd-java:typeIs('java.lang.Object'))
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/Type[pmd-java:typeIs('java.util.Set') and ReferenceType//TypeArgument[1][not(pmd-java:typeIs('java.lang.Comparable'))
@@ -1947,6 +1894,8 @@ or ancestor::MethodDeclaration//PrimaryExpression/PrimaryPrefix/Name/@Image = co
 ]/../..
                ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1992,11 +1941,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Resource//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.FileInputStream') or pmd-java:typeIs('java.io.FileOutputStream')]
@@ -2004,6 +1948,8 @@ class Foo {
 [not (ancestor::TryStatement//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.io.BufferedInputStream') or pmd-java:typeIs('BufferedOutputStream')])]
 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2038,11 +1984,6 @@ class BufferFileStreaming {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[pmd-java:typeIs('java.nio.file.Files') and ends-with(@Image,'.newOutputStream')]
@@ -2054,6 +1995,8 @@ and (not(.//PrimaryPrefix/Name[pmd-java:typeIs('org.apache.commons.io.IOUtils') 
 ]]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2083,15 +2026,13 @@ class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[@Image='Files.readAllBytes' or @Image='Files.readAllLines']
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2127,8 +2068,6 @@ class Good {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[@Name='equals' and MethodDeclarator/FormalParameters/@Size=1 and @Public=true() and @Static=false()]
@@ -2136,6 +2075,8 @@ class Good {
 /Block[count(./BlockStatement/Statement) = 1][count(.//ArgumentList) = 0]//PrimaryExpression[PrimaryPrefix[@SuperModifier=true()]]/PrimarySuffix[@Image='hashCode']
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -2181,11 +2122,6 @@ class Good {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[not((@Name='main' and @Static=true())or ../Annotation//Name/@Image='PostConstruct'
@@ -2194,6 +2130,8 @@ or .//IfStatement//EqualityExpression[@Operator='=='][
 //AllocationExpression[pmd-java:typeIs('java.security.Provider')]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/common_std.xml
+++ b/src/main/resources/category/java/common_std.xml
@@ -17,11 +17,6 @@
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -44,6 +39,8 @@
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -71,11 +68,6 @@ public class FileStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
@@ -86,6 +78,8 @@ PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'
 //ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
 	         ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -122,10 +116,6 @@ public class DateStuff {
             </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration/Block/BlockStatement[
@@ -142,6 +132,8 @@ ancestor::Block//LocalVariableDeclaration[@Final=true()]//VariableDeclaratorId/@
 ]]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -173,10 +165,6 @@ public class StringStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ForStatement | //WhileStatement | //DoStatement)//AssignmentOperator[
@@ -191,6 +179,8 @@ public class StringStuff {
 	]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -228,10 +218,6 @@ public class StringStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="3" type="String" description="Maximum number of allowed static imports with wildcard"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -239,6 +225,8 @@ public class StringStuff {
 	]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -271,9 +259,6 @@ import static com.co.corporate.Constants.GREAT; // good
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[@Image='Serializable']
@@ -293,6 +278,8 @@ and (pmd-java:typeIs('java.lang.Object'))]))
 ]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -331,9 +318,6 @@ class Baz extends RemoteException {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="brain-overload" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-max" value="5" type="String" description="Maximum number of allowed non-setter statements"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -343,6 +327,8 @@ class Baz extends RemoteException {
 ]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -388,9 +374,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="brain-overload" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="param-block-max" value="1" type="String" description="Maximum allowed depth of lambda-with-code-block nesting"/>
             <property name="param-single-max" value="4" type="String" description="Maximum allowed depth of lambda-single-expression nesting"/>
             <property name="xpath">
@@ -400,6 +383,8 @@ class Foo {
 //LambdaExpression[Expression][count(ancestor::LambdaExpression) > number($param-single-max)]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -439,10 +424,6 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unused" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for each assignment node :)
@@ -480,6 +461,8 @@ return ($node[
 )
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,replaces-sonar-rule,suspicious,unused" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -499,8 +482,6 @@ return ($node[
         </description>
         <priority>4</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression[(PrimaryPrefix/Name|PrimarySuffix)[ends-with(@Image, 'forEach')]]
@@ -510,6 +491,8 @@ return ($node[
 )]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/concurrent.xml
+++ b/src/main/resources/category/java/concurrent.xml
@@ -12,10 +12,6 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -37,6 +33,8 @@
 ]    ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -50,9 +48,6 @@
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -93,6 +88,8 @@
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -117,8 +114,6 @@
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -153,6 +148,8 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -178,8 +175,6 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[pmd-java:typeIs('javax.xml.bind.Marshaller')
@@ -188,6 +183,8 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
  or pmd-java:typeIs('javax.xml.validation.Validator')]
 			]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -206,9 +203,6 @@ ancestor::StatementExpression/PrimaryExpression/PrimaryPrefix/Name/@Image = ance
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -244,6 +238,8 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -259,8 +255,6 @@ or ancestor::MethodDeclaration[@Name='afterPropertiesSet']
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -287,6 +281,8 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -306,9 +302,6 @@ and not (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Auto
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -346,6 +339,8 @@ and not (../Annotation//Name[@Image='GuardedBy'])
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -365,9 +360,6 @@ and not (../Annotation//Name[@Image='GuardedBy'])
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -401,6 +393,8 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
                     ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -417,8 +411,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -437,6 +429,8 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -456,8 +450,6 @@ or (ancestor::ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='VisibleFo
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -486,6 +478,8 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -500,8 +494,6 @@ or (VariableDeclarator/VariableDeclaratorId/@Name = ancestor::ClassOrInterfaceBo
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -516,6 +508,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -549,8 +543,6 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -587,6 +579,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -621,9 +615,6 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             Solution: Use thread locals or create the Factories as local variables and anyway use properties to specify the implementation class. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //ClassOrInterfaceBodyDeclaration//FieldDeclaration[@Static=true() and (
@@ -640,6 +631,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -663,8 +656,6 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             Solution: Guard the field properly with synchronized or use atomics like AtomicInteger. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/(AssignmentOperator[@Image='+=' or @Image='-=']/..|
@@ -673,6 +664,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
                         ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -702,9 +695,6 @@ or ancestor::SynchronizedStatement/Expression//Name)]
             Solution: Since only one thread can access the field, there is no need for violatile and it can be removed. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //FieldDeclaration[@Volatile = true() and
@@ -713,6 +703,8 @@ or ancestor::SynchronizedStatement/Expression//Name)]
                         ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -744,12 +736,6 @@ class Good {
             Solution: Remove synchronized because local variables are only accessible by the owning thread and are not shared. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-	        <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: var.x() in synchronized block, var in list of local vars and all var.x in synchronized block are local vars:)
@@ -764,6 +750,8 @@ count(distinct-values(ancestor::MethodDeclaration//LocalVariableDeclaration//Var
                         ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -806,10 +794,6 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -840,6 +824,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -882,11 +868,6 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-	        <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -897,6 +878,8 @@ and not (../PrimarySuffix[ends-with(@Image, 'Timeout')])]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -929,10 +912,6 @@ public class Foo {
             It assumes CPU intensive non-blocking processing of in-memory data.  (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-	        <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: assumption: if import of web client / http client is present, parallelStreaming is for remote calls :)
@@ -945,6 +924,8 @@ and not(ancestor::Block//StatementExpression/PrimaryExpression/PrimaryPrefix/Nam
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -992,11 +973,6 @@ public class Foo {
             Solution: Do *not* put the user related data in a shared object e.g. by Spring @Component annotation. Use a POJO. Or, if it is not user data, rename the field. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
-	        <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/Annotation//Name[(@Image='Component' or @Image='Service' or @Image='Controller' or @Image='RestController' or @Image='Repository' or
@@ -1012,6 +988,8 @@ and not ((ancestor::TypeDeclaration/Annotation//Name[@Image='ConfigurationProper
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,data-mix-up,jpinpoint-rule,multi-threading,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1065,12 +1043,6 @@ public class VMRData {
             So only for large collections and much processing without having to wait.   (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="unpredictable" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/(PrimarySuffix[@Image='parallelStream' or @Image='parallel']|PrimaryPrefix/Name[ends-with(@Image, '.parallelStream') or ends-with(@Image, '.parallel')])
@@ -1081,6 +1053,8 @@ public class VMRData {
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low,unpredictable" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1145,18 +1119,14 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimarySuffix[@Image='parallel' and ../PrimaryPrefix/Name[@Image = 'Flux.fromIterable']
 and //ImportDeclaration/Name[starts-with(@Image, 'reactor.core.publisher')]]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1196,11 +1166,6 @@ class FooGood {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix/Name[@Image='MDC.setContextMap' and
@@ -1208,6 +1173,8 @@ class FooGood {
 or ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter[pmd-java:typeIs('reactor.util.context.Context')])]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1251,15 +1218,13 @@ class FooGood {
             Solution: Just do processing when and where actually needed. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix/Name[@Image='Hooks.onEachOperator']
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1290,10 +1255,6 @@ public class FooBad {
             Solution: Provide a timeout to the invokeAll/invokeAny method and handle the timeout. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression[PrimarySuffix[@ArgumentCount=1]]/PrimaryPrefix
@@ -1301,6 +1262,8 @@ public class FooBad {
 /../PrimarySuffix//ArgumentList
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/enterprise.xml
+++ b/src/main/resources/category/java/enterprise.xml
@@ -12,12 +12,6 @@
         (jpinpoint-rules)</description>
     <priority>3</priority>
     <properties>
-        <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-        <property name="tag" value="confusing" type="String" description="for-sonar"/>
-        <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-        <property name="tag" value="performance" type="String" description="for-sonar"/>
-        <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-        <property name="tag" value="cpu" type="String" description="for-sonar"/>
         <property name="xpath">
             <value>
                 <![CDATA[
@@ -29,6 +23,8 @@ and (count(ancestor::TypeDeclaration//MethodDeclaration[@Public=true() and not(e
                 ]]>
             </value>
         </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
     </properties>
     <example>
         <![CDATA[

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -8,10 +8,6 @@
         Solutions: Upgrade to httpclient-4.5+ and use org.apache.http.impl.conn.PoolingHttpClientConnectionManager and e.g. org.apache.http.impl.client.HttpClientBuilder. (jpinpoint-rules)</description>
     <priority>2</priority>
     <properties>
-        <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-        <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-        <property name="tag" value="deprecated" type="String" description="for-sonar"/>
-        <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
         <property name="xpath">
             <value><![CDATA[
 //ImportDeclaration/Name[@Image='org.apache.commons.httpclient.SimpleHttpConnectionManager'
@@ -40,6 +36,8 @@ or pmd-java:typeIs('org.apache.commons.httpclient.MultiThreadedHttpConnectionMan
 ]
 		     ]]></value>
         </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,deprecated,jpinpoint-rule,multi-threading" type="String" description="classification"/>
     </properties>
         <example>
             <![CDATA[
@@ -63,10 +61,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[not (Annotation//Name[@Image='PostConstruct'])]
@@ -74,6 +68,8 @@ class Good {
  /PrimaryExpression/PrimaryPrefix/Name[@Image = 'JAXBContext.newInstance']
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -83,10 +79,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -103,6 +95,8 @@ class Good {
 ]/VariableInitializer//PrimaryPrefix/Name[ends-with(@Image, 'build')]
 			]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
          </properties>
         <example>
             <![CDATA[
@@ -124,10 +118,6 @@ public static JsonMapper createMapper() {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//Expression/PrimaryExpression/PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
@@ -141,6 +131,8 @@ public static JsonMapper createMapper() {
 ]
 			]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -151,10 +143,6 @@ public static JsonMapper createMapper() {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //TypeDeclaration/ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/
@@ -164,6 +152,8 @@ FieldDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.
 MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('javax.xml.datatype.XMLGregorianCalendar')]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -174,10 +164,6 @@ MethodDeclaration//LocalVariableDeclaration/Type/ReferenceType/ClassOrInterfaceT
             Solution: HttpClients should disable connection state tracking in order to reuse TLS connections, since service calls for one pool have the same user identity/security context for all sessions. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (:locally created http client builder without disableConnectionState :)
@@ -192,6 +178,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 			]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -203,8 +191,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Either use 1. setConnectionManager and call setMaxTotal and setDefaultMaxPerRoute on that connection manager, or 2. no ConnectionManager: call setMaxConnTotal and setMaxConnPerRoute on the client directly. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder without setMaxConnTotal/setMaxConnPerRoute :)
@@ -245,6 +231,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -272,8 +260,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             2. not use a ConnectionManager and call setMaxConnTotal and setMaxConnPerRoute on the client directly (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="correctness" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: locally created http client builder with setConnectionManager and at least one of setMaxConnTotal/setMaxConnPerRoute :)
@@ -298,6 +284,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -325,10 +313,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Solution: Set the timeouts explicitly to proper reasoned values. See best practice values via the link. Use the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the timeouts.(jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="pitfall" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: only for Apache http client 4 :)
@@ -393,6 +377,8 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,pitfall" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -414,10 +400,6 @@ ancestor::MethodDeclaration//PrimarySuffix/@Image="disableConnectionState")]
             Solution: switch to a Feign client that supports HTTP connection pooling with mTLS, for instance Apache HttpClient 4 with disableConnectionState and proper connection pool size and timeouts. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: default client constructor with sslSocketFactory :)
@@ -426,6 +408,8 @@ and not(ancestor::Expression//Arguments[ArgumentList/@Size=2]//Expression[1]//Nu
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -462,15 +446,13 @@ public class MyFeignClient {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('javax.xml.bind.JAXB')]
 	         ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -493,8 +475,6 @@ public class XMLConversion {
             Solution: Use ClosableHttpClient to allow for invoking close on it to properly close the connection. Or use HttpComponentsClientHttpRequestFactory(httpClient) to let it manage closing. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: bad: HttpClient without HttpComponentsClientHttpRequestFactory :)
@@ -511,6 +491,8 @@ public class XMLConversion {
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
         <![CDATA[
@@ -538,8 +520,6 @@ public class XMLConversion {
             Solution: Avoid configuring objectMappers except when initializing: right after construction. It is recommended to create ObjectReaders and ObjectWriters from ObjectMapper and pass those around since they are immutable and therefore thread-safe. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: exclude method annotated with PostConstruct :)
@@ -565,6 +545,8 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -601,14 +583,14 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
             Solution: Netflix recommends to use open source alternatives like resilience4j. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="deprecated" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImportDeclaration/Name[starts-with(@Image, "com.netflix.hystrix")]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="deprecated,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
         </example>
@@ -621,10 +603,6 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
             Solution: Create/build HttpClient with proper connection pooling and timeouts once, and then use it for requests. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
    //TypeDeclaration/ClassOrInterfaceDeclaration[count(.//Annotation//Name[@Image='Configuration']) = 0]
@@ -634,6 +612,8 @@ or ancestor::ClassOrInterfaceBody[count(.//MethodDeclaration/ResultType/Type[pmd
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -657,12 +637,6 @@ class Foo {
             Solution: Have the retry mechanism in one location in the chain only, recommended only the one closest to the user. (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="resilience" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Retry']
@@ -673,6 +647,8 @@ class Foo {
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,resilience,suspicious,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -696,16 +672,14 @@ public class Foo {
             Solution: Remove Hooks.onOperatorDebug() when not debugging. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //StatementExpression/PrimaryExpression/PrimaryPrefix[pmd-java:typeIs('reactor.core.publisher.Hooks')]//Name[ends-with(@Image, 'Hooks.onOperatorDebug')]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -729,8 +703,6 @@ public class Foo {
             Solution: Don't use both on the same factory, provide the HttpClient only once to the factory. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Statement[StatementExpression[//ArgumentList]/PrimaryExpression/PrimaryPrefix/Name/@Image =
@@ -739,6 +711,8 @@ ancestor::MethodDeclaration//VariableDeclarator[.//AllocationExpression/ClassOrI
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -776,15 +750,14 @@ class Good {
             Solution: Use the HttpHost constructor with 2 (including port) or preferably 3 arguments (including port and protocol). (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression[pmd-java:typeIs("org.apache.http.HttpHost")]/Arguments/ArgumentList[count(./Expression) = 1]/../..
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -814,16 +787,14 @@ class Foo {
             Solution: Provide your own supplier with explicit pool sizing and timeouts by a class implementing Supplier. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //AllocationExpression/ClassOrInterfaceType[@Image='ClientHttpRequestFactorySupplier']
 [/CompilationUnit/ImportDeclaration/Name[starts-with(@Image, 'org.springframework.boot.web.client')]]]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,jpinpoint-rule,performance,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -874,11 +845,6 @@ and use it to replace the bad line in Bad example:
             Note that the pool will only grow beyond CorePoolSize up to MaxPoolSize when the queue is full. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //LocalVariableDeclaration//AllocationExpression/ClassOrInterfaceType[@Image='ThreadPoolTaskExecutor']
@@ -887,6 +853,8 @@ and use it to replace the bad line in Bad example:
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -919,11 +887,6 @@ and use it to replace the bad line in Bad example:
             Solution: Avoid multiple reads of the response body so it is not needed. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: somehow typeIs does not work with spring-web-6.0, do it old school way :)
@@ -932,6 +895,8 @@ and use it to replace the bad line in Bad example:
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -964,10 +929,6 @@ public class Foo {
             Solution: Set connectTimeout and connectionRequestTimeout to values based om tests, for instance 200 ms and 250 ms. respectively (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (: use of field, local var and return statement :)
@@ -995,6 +956,8 @@ ancestor::ClassOrInterfaceDeclaration[//LocalVariableDeclaration/Type
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1027,8 +990,6 @@ public class HttpClientStuff {
             Also when used like jaxMsgConverter.setObjectMapper(objectMapper) it is not considered a violation. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (for $node in (//FieldDeclaration[pmd-java:typeIs('com.fasterxml.jackson.databind.ObjectMapper')
@@ -1045,6 +1006,8 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1073,16 +1036,14 @@ and not($node/@Name = ancestor::ClassOrInterfaceDeclaration//PrimaryExpression[P
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//VariableDeclarator[pmd-java:typeIs('io.axual.client.producer.Producer')]
 [ancestor::TypeDeclaration[count(./Annotation//Name[@Image='Configuration'])=0]]
 			]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1123,10 +1084,6 @@ class AxualProducerGood2{
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//PrimaryPrefix/Name[pmd-java:typeIs('io.github.resilience4j.retry.Retry') and ends-with(@Image, '.getEventPublisher')]
@@ -1137,6 +1094,8 @@ class AxualProducerGood2{
 /VariableDeclarator/VariableDeclaratorId/@Name), substring-before(@Image,'.')))]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1178,9 +1137,6 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[Type/@TypeImage='int']/VariableDeclarator[VariableDeclaratorId[@Final = true()][contains(upper-case(@Name), 'TIMEOUT') or contains(upper-case(@Name), 'DURATIONOUT')
@@ -1188,6 +1144,8 @@ or(contains(upper-case(@Name), 'MAX') and contains(upper-case(@Name), 'ROUTE'))]
 [VariableInitializer//Literal or VariableDeclaratorId/@Name=ancestor::ClassOrInterfaceBody//ConstructorDeclaration//StatementExpression[Expression//Literal]//Name/@Image]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -1228,10 +1186,6 @@ class AvoidHardcodedConnectionConfig {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Type//ClassOrInterfaceType[@Image='SaajSoapMessageFactory'
@@ -1241,6 +1195,8 @@ and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[
 and not (ancestor::ClassOrInterfaceBody//PrimaryExpression[./PrimaryPrefix/Name[@Image='System.setProperty'] and ./PrimarySuffix/Arguments//Literal[@Image='"javax.xml.transform.TransformerFactory"']])]
                 ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/spring.xml
+++ b/src/main/resources/category/java/spring.xml
@@ -17,10 +17,6 @@
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -37,6 +33,8 @@ exists(./Annotation//Name[@Image='Component' or @Image='Service' or @Image='Cont
                     ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="confusing,data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -59,10 +57,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -73,6 +67,8 @@ MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Annotation/M
 Annotation//Name[@Image='RenderMapping'])]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -86,10 +82,6 @@ Annotation//Name[@Image='RenderMapping'])]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -101,6 +93,8 @@ and (
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -115,10 +109,6 @@ and (
             redirect:/redirectUrl?someAttribute={someAttribute}.</description>
         <priority>1</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (
@@ -149,6 +139,8 @@ and (
 )
             ]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -166,8 +158,6 @@ and (
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -186,6 +176,8 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -196,10 +188,6 @@ and  (../../ClassOrInterfaceBodyDeclaration/Annotation//Name[@Image='Autowired']
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration
@@ -210,6 +198,8 @@ Annotation//Name[@Image='ActionMapping']) and
 count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -220,15 +210,13 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,'.clear')])=0]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']/MemberValuePairs/MemberValuePair[@MemberName='key']
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -249,11 +237,6 @@ class Bad1 {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="multi-threading" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ClassOrInterfaceBodyDeclaration//Annotation/NormalAnnotation[Name/@Image='Cacheable']
@@ -261,6 +244,8 @@ class Bad1 {
 //ClassOrInterfaceBodyDeclaration//Annotation/MarkerAnnotation[Name/@Image='Cacheable'])[count(MemberValuePairs/MemberValuePair[@MemberName='sync']) = 0]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -285,14 +270,13 @@ class Good1 {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
     //AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.support.SimpleCacheManager') or pmd-java:typeIs('org.springframework.cache.concurrent.ConcurrentMapCache')]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -324,11 +308,6 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-low" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImplementsList/ClassOrInterfaceType[pmd-java:typeIs("org.springframework.cache.interceptor.KeyGenerator")]
@@ -346,6 +325,8 @@ ForStatement[./Expression//Name[@Image = ancestor::MethodDeclaration//FormalPara
 )
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -382,15 +363,14 @@ public class Good implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation//Name[@Image='Cacheable']
 /../MemberValuePairs[count(MemberValuePair[@Image='keyGenerator']) = 0]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -420,9 +400,6 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[ImplementsList/ClassOrInterfaceType[pmd-java:typeIs('org.springframework.cache.interceptor.KeyGenerator')]]
@@ -442,6 +419,8 @@ class Foo {
 ]/../Arguments
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -477,9 +456,6 @@ class GoodCacheKeyGenerator implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceBodyDeclaration[.//NormalAnnotation/Name[@Image='Cacheable']]
@@ -493,6 +469,8 @@ class GoodCacheKeyGenerator implements KeyGenerator {
   ]
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -528,16 +506,14 @@ class MyObject {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="confusing" type="String" description="for-sonar"/>
-            <property name="tag" value="bad-practice" type="String" description="for-sonar"/>
-            <property name="tag" value="data-mix-up" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassOrInterfaceDeclaration[@SimpleName = 'CacheKeyGenerator' and @Interface = false() and @Abstract = false()]
 /ImplementsList/ClassOrInterfaceType[@Image='KeyGenerator']
 	]]></value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="bad-practice,confusing,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/main/resources/category/java/sql.xml
+++ b/src/main/resources/category/java/sql.xml
@@ -12,10 +12,6 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -29,6 +25,8 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -42,11 +40,6 @@ ancestor::ClassOrInterfaceBody//VariableDeclarator/VariableDeclaratorId/@Name
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-medium" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -59,6 +52,8 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
         </properties>
     </rule>
 
@@ -72,8 +67,6 @@ count(.//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, '.getSingleResul
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -103,6 +96,8 @@ ancestor::BlockStatement//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[
@@ -126,12 +121,6 @@ ancestor::BlockStatement//PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image,
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="performance" type="String" description="for-sonar"/>
-            <property name="tag" value="sustainability-high" type="String" description="for-sonar"/>
-            <property name="tag" value="cpu" type="String" description="for-sonar"/>
-            <property name="tag" value="memory" type="String" description="for-sonar"/>
-            <property name="tag" value="io" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -148,6 +137,8 @@ concat(ancestor::MethodDeclaration//VariableDeclarator[./VariableInitializer//Na
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         </properties>
         <example>
             <![CDATA[


### PR DESCRIPTION
On merge it collects all property "tag" in property "tags" with comma separated list.

Seems more convenient to use the separate tags in the original files, and then bring them together on merge. Agree?

--> the original files can be converted as well, right? Seems a bit confusing to have two formats. I'd prefer to have the original file be converted as well.

--> can be done indeed, have xsl scripts counting/reporting the number of tags that were a bit simpler with separate property tags :-)