### PR TITLE
merged all tags from main (pmd6) to pmd7

### DIFF
--- a/src/main-todo/resources/category/java/common_std.xml
+++ b/src/main-todo/resources/category/java/common_std.xml
@@ -15,11 +15,7 @@
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
-            <property name="tag" value="unused" type="String" description="for-sonar"/>
-            <property name="tag" value="suspicious" type="String" description="for-sonar"/>
-            <property name="tag" value="replaces-sonar-rule" type="String" description="for-sonar"/>
-            <property name="version" value="2.0"/>
+            <property name="tags" value="jpinpoint-rule,replaces-sonar-rule,suspicious,unused" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for each assignment node :)

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -12,7 +12,6 @@
         </description>
         <priority>1</priority>
         <properties>
-            <property name="pmd-version" value="7" type="String" description="for-compatibility"/>
             <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -58,7 +57,6 @@ public class CDIStuff {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="pmd-version" value="7" type="String" description="for-compatibility"/>
             <property name="tags" value="jpinpoint-rule,bad-practice" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -93,7 +91,6 @@ public enum Animal {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="pmd-version" value="7" type="String" description="for-compatibility"/>
             <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -13,7 +13,7 @@
         <priority>1</priority>
         <properties>
             <property name="pmd-version" value="7" type="String" description="for-compatibility"/>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[@MethodName='select']/MethodCall[@MethodName='current']/TypeExpression/ClassType[@SimpleName='CDI'
@@ -160,7 +160,7 @@ and not (preceding-sibling::SwitchLabel[@Default=true()])]
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (:- method calls for non-short regex literals and used fields defined with non-short regex literal, or not defined as field -:)
@@ -206,7 +206,7 @@ String good_replaceInnerLineBreakBySpace() {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall[pmd-java:matchesSig('java.io.ByteArrayOutputStream#new()') or pmd-java:matchesSig('java.io.StringWriter#new()')
@@ -249,7 +249,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //AssignmentExpression[@Operator='+='][VariableAccess/@Name=ancestor::Block//VariableDeclarator/VariableId[pmd-java:typeIs('java.lang.String')]/@Name]
@@ -290,7 +290,7 @@ class ConcatsExample {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//MethodCall[pmd-java:matchesSig('java.util.regex.Pattern#compile(java.lang.String)')
@@ -329,7 +329,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//MethodCall[pmd-java:matchesSig('javax.xml.xpath.XPath#compile(java.lang.String)') or
@@ -383,7 +383,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -418,7 +418,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[starts-with(@MethodName, 'reflection')][(TypeExpression|ConstructorCall)
@@ -460,7 +460,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall/ClassType[pmd-java:typeIs('java.text.SimpleDateFormat')
@@ -496,7 +496,7 @@ public class Foo {
             Solution: Replace StringBuffer by StringBuilder.  (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall/ClassType[pmd-java:typeIs('java.lang.StringBuffer')]
@@ -526,7 +526,7 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall
@@ -583,7 +583,7 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('javax.xml.xpath.XPath#compile(java.lang.String)')]/ArgumentList/StringLiteral[starts-with(@Image, '"//')]
@@ -616,7 +616,7 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall/TypeExpression/ClassType[pmd-java:typeIs('org.apache.xpath.XPathAPI')]
@@ -635,7 +635,7 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('javax.xml.xpath.XPathFactory#newInstance()')]
@@ -656,7 +656,7 @@ public class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,correctness" type="String" description="classification"/>
+            <property name="tags" value="correctness,jpinpoint-rule,performance" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -706,7 +706,7 @@ class Good {
             Solution: Use SLF4J formatting with {}-placeholders or log and format conditionally.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall
@@ -741,7 +741,7 @@ class Foo {
             Solution: Execute the operation only conditionally and utilize SLF4J formatting with {}-placeholders.  (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall
@@ -781,7 +781,7 @@ class Foo {
             Solution: Suppress warnings judiciously based on full knowledge and report reasons to suppress (false positives) to the rule maintainers so the rule can be fixed. (jpinpoint-rules)</description>
         <priority>4</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,suspicious,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
             <property name="ruleIdMatches" type="String" value="AvoidUserDataInSharedObjects|AvoidUnguardedMutableFieldsInSharedObjects|AvoidUnguardedAssignmentToNonFinalFieldsInSharedObjects|AvoidMutableStaticFields|[^\w]ALL[^\w]|[^\w]all[^\w]|PMD[^\.]|pmd[^:]"
                       description="Regex for inclusion of high risk rules"/>
             <property name="ruleIdNotMatches" type="String" value="^$"
@@ -837,7 +837,7 @@ class VMRData {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall
@@ -886,7 +886,7 @@ class Foo {
             Solution: Specify the time unit in the identifier, like connectTimeoutMillis. (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,confusing" type="String" description="classification"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: for fields, formal parameters and local variables :)
@@ -1028,7 +1028,7 @@ class LombokGetterGood {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,correctness" type="String" description="classification"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: the number of toLowerCase on a field used in equals should not be larger than that of hashCode :)
@@ -1121,7 +1121,6 @@ class Good {
         </example>
     </rule>
 
-
     <rule name="FieldOfHashCodeMissingInEquals"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           language="java"
@@ -1131,7 +1130,7 @@ class Good {
             Solution: When objects are equal, hashCode needs to be equal, too. Use the same fields in equals and hashCode. (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,correctness" type="String" description="classification"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration/VariableDeclarator[
@@ -1373,7 +1372,7 @@ public class Good {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,bad-practice" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: append used in one chained statement on constructor of StringBuilder and with chained toString :)
@@ -1429,7 +1428,7 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //(FieldDeclaration|LocalVariableDeclaration)[
@@ -1542,7 +1541,7 @@ record GoodRecord(String name, List<String> list) {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,bad-practice,confusing" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,confusing,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //VariableId[matches(@Name, 'VALUE|VAL|INTEGER|INT|LONG|NUMBER|NUM|[0-9]+|ZERO|ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN|TWENTY', 'i')
@@ -1582,7 +1581,7 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //EnumDeclaration/EnumBody[count(EnumConstant) > 3]//MethodDeclaration/Block
@@ -1646,7 +1645,7 @@ public enum Fruit {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: check key type in declaration :)
@@ -1699,7 +1698,7 @@ public enum Fruit {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: declared variable used in Set by-element access :)
@@ -1755,7 +1754,7 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //Resource//ConstructorCall[pmd-java:typeIs('java.io.FileInputStream') or pmd-java:typeIs('java.io.FileOutputStream')]
@@ -1796,7 +1795,7 @@ class BufferFileStreaming {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[TypeExpression[pmd-java:typeIs('java.nio.file.Files')]
@@ -1835,7 +1834,7 @@ class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//MethodCall[pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
@@ -1879,7 +1878,7 @@ class Good {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,correctness" type="String" description="classification"/>
+            <property name="tags" value="correctness,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[@Name='equals' and FormalParameters/@Size=1 and @Static=false() and ModifierList/@ExplicitModifiers='public']
@@ -1932,7 +1931,7 @@ class Good {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration

--- a/src/main/resources/category/java/common_std.xml
+++ b/src/main/resources/category/java/common_std.xml
@@ -16,7 +16,7 @@
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="io,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -51,7 +51,7 @@
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -98,7 +98,7 @@ public class DateStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (//ForeachStatement | //WhileStatement | //DoStatement)//AssignmentExpression[
@@ -145,7 +145,7 @@ public class StringStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //(ReturnStatement|ExpressionStatement|LocalVariableDeclaration)
@@ -187,7 +187,7 @@ public class StringStuff {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,pitfall,confusing,replaces-sonar-rule" type="String" description="classification"/>
+            <property name="tags" value="confusing,jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
             <property name="param-max" value="3" type="String" description="Maximum number of allowed static imports with wildcard"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -285,7 +285,7 @@ class Baz extends RemoteException {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,brain-overload,replaces-sonar-rule" type="String" description="classification"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
             <property name="param-max" value="5" type="String" description="Maximum number of allowed non-setter statements"/>
             <property name="xpath">
                 <value><![CDATA[
@@ -338,7 +338,7 @@ class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,brain-overload,replaces-sonar-rule" type="String" description="classification"/>
+            <property name="tags" value="brain-overload,jpinpoint-rule,replaces-sonar-rule" type="String" description="classification"/>
             <property name="param-block-max" value="1" type="String" description="Maximum allowed depth of lambda-with-code-block nesting"/>
             <property name="param-single-max" value="4" type="String" description="Maximum allowed depth of lambda-single-expression nesting"/>
             <property name="xpath">
@@ -388,7 +388,7 @@ class Foo {
         </description>
         <priority>4</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,bad-practice" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: should match java.lang.Iterable#forEach(java.util.function.Consumer) but also others like java.util.stream.IntStream#forEach(java.util.function.IntConsumer) :)

--- a/src/main/resources/category/java/concurrent.xml
+++ b/src/main/resources/category/java/concurrent.xml
@@ -12,7 +12,7 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -74,7 +74,7 @@ public static String good(CompletableFuture<String> complFuture) throws Exceptio
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: -- GuardedBy annotations are matched on SimpleName, so it matches all known GuardedBy annotations :)
@@ -186,7 +186,7 @@ class Exporter {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,multi-threading,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: annotations that make singleton like components in Spring and EJB :)
@@ -303,7 +303,7 @@ class MyService {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,multithreading" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,multi-threading" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -527,7 +527,7 @@ class BadMutebleTypes {
             (jpinpoint-rules)</description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,multi-threading,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,multi-threading" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -1015,7 +1015,7 @@ public class Good {
                 Solution: Create the Factories as local variables and use command line arguments to specify the implementation class. (jpinpoint-rules)</description>
             <priority>1</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+                <property name="tags" value="jpinpoint-rule,multi-threading,pitfall" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //ClassDeclaration//FieldDeclaration[
@@ -1099,7 +1099,7 @@ public class Good {
                 Solution: Since only one thread can access the field, there is no need for volatile and it can be removed. (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,confusing" type="String" description="classification"/>
+                <property name="tags" value="confusing,jpinpoint-rule,multi-threading" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
  //FieldDeclaration[
@@ -1137,7 +1137,7 @@ public class Good {
                 Solution: Remove synchronized because local variables are only accessible by the owning thread and are not shared. (jpinpoint-rules)</description>
             <priority>3</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance, confusing" type="String" description="classification"/>
+                <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //SynchronizedStatement[
@@ -1187,7 +1187,7 @@ public class Good {
                 (jpinpoint-rules)</description>
             <priority>1</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+                <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
                 <property name="xpath">
                     <value>
                         <![CDATA[
@@ -1247,7 +1247,7 @@ public class Good {
                 (jpinpoint-rules)</description>
             <priority>1</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification"/>
+                <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall,unpredictable" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('java.util.concurrent.CompletableFuture#supplyAsync(_)')]
@@ -1343,7 +1343,7 @@ public class Good {
                 Solution: Do *not* put the user related data in a shared object e.g. by Spring @Component annotation. Use a POJO. Or, if it is not user data, rename the field. (jpinpoint-rules)</description>
             <priority>1</priority>
             <properties>
-                <property name="tag" value="jpinpoint-rule,multi-threading,correctness,suspicious,data-mix-up" type="String" description="classification"/>
+                <property name="tags" value="correctness,data-mix-up,jpinpoint-rule,multi-threading,suspicious" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 (: annotations that make singleton like components in Spring and EJB :)
@@ -1434,7 +1434,7 @@ public class Good {
                 So only for large collections and much processing without having to wait.   (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tag" value="jpinpoint-rule,multi-threading,performance,unpredictable" type="String" description="classification"/>
+                <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low,unpredictable" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[
@@ -1511,7 +1511,7 @@ public class Good {
                 (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance,bad-practice" type="String" description="classification"/>
+                <property name="tags" value="bad-practice,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('reactor.core.publisher.Flux#parallel(_)') and ./MethodCall[pmd-java:matchesSig('reactor.core.publisher.Flux#fromIterable(_)')]]
@@ -1556,7 +1556,7 @@ public class Good {
                 (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+                <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-medium" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[
@@ -1618,7 +1618,7 @@ public class Good {
                 Solution: Just do processing when and where actually needed. (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+                <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('reactor.core.publisher.Hooks#onEachOperator(_,_)')]
@@ -1654,7 +1654,7 @@ public class FooBad {
                 Solution: Provide a timeout to the invokeAll/invokeAny method and handle the timeout. (jpinpoint-rules)</description>
             <priority>2</priority>
             <properties>
-                <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+                <property name="tags" value="jpinpoint-rule,multi-threading,performance,pitfall" type="String" description="classification"/>
                 <property name="xpath">
                     <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('java.util.concurrent.ExecutorService#invokeAll(_)') or pmd-java:matchesSig('java.util.concurrent.ExecutorService#invokeAny(_)')]

--- a/src/main/resources/category/java/enterprise.xml
+++ b/src/main/resources/category/java/enterprise.xml
@@ -13,7 +13,7 @@
         (jpinpoint-rules)</description>
     <priority>3</priority>
     <properties>
-        <property name="tags" value="jpinpoint-rule, confusing, multi-threading,performance" type="String" description="classification"/>
+        <property name="tags" value="confusing,cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
         <property name="xpath">
             <value>
                 <![CDATA[

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -11,7 +11,7 @@
         Solutions: Upgrade to httpclient-4.5+ and use org.apache.http.impl.conn.PoolingHttpClientConnectionManager and e.g. org.apache.http.impl.client.HttpClientBuilder. (jpinpoint-rules)</description>
     <priority>2</priority>
     <properties>
-        <property name="tags" value="jpinpoint-rule,multi-threading,deprecated,data-mix-up" type="String" description="classification"/>
+        <property name="tags" value="data-mix-up,deprecated,jpinpoint-rule,multi-threading" type="String" description="classification"/>
         <property name="xpath">
             <value><![CDATA[
 //ImportDeclaration[starts-with(@ImportedName, 'org.apache.commons.httpclient')
@@ -64,7 +64,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[not(pmd-java:hasAnnotation('javax.annotation.PostConstruct') or pmd-java:hasAnnotation('jakarta.annotation.PostConstruct'))]
@@ -87,7 +87,7 @@ class Good {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: ObjectMapper constructor called in a method :)
@@ -130,7 +130,7 @@ return JsonMapper.builder().build(); // bad
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassDeclaration[not (pmd-java:hasAnnotation('org.springframework.context.annotation.Configuration'))]//MethodDeclaration/(
@@ -155,7 +155,7 @@ return JsonMapper.builder().build(); // bad
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassType[pmd-java:typeIs('javax.xml.datatype.XMLGregorianCalendar')]
@@ -180,7 +180,7 @@ return JsonMapper.builder().build(); // bad
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[
@@ -211,7 +211,7 @@ return JsonMapper.builder().build(); // bad
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,performance,resilience" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration
@@ -274,7 +274,7 @@ return HttpClientBuilder.create() // good, setConnectionManager called, pool con
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,correctness" type="String" description="classification"/>
+            <property name="tags" value="correctness,jpinpoint-rule,resilience" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[
@@ -326,8 +326,7 @@ return HttpClientBuilder.create() // good
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,suspicious" type="String"
-                      description="classification"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,pitfall,resilience" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration
@@ -397,7 +396,7 @@ return HttpClientBuilder.create() // good
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: default client constructor with sslSocketFactory :)
@@ -442,7 +441,7 @@ public class MyFeignClient {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassType[pmd-java:typeIs('javax.xml.bind.JAXB') or pmd-java:typeIs('jakarta.xml.bind.JAXB')]
@@ -591,7 +590,7 @@ void good2() {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,deprecated" type="String" description="classification"/>
+            <property name="tags" value="deprecated,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImportDeclaration[starts-with(@ImportedName, "com.netflix.hystrix")]
@@ -617,7 +616,7 @@ void good2() {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassDeclaration[not(pmd-java:hasAnnotation('org.springframework.context.annotation.Configuration'))]
@@ -660,8 +659,7 @@ class Foo {
         </description>
         <priority>5</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,resilience,suspicious" type="String"
-                      description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,resilience,suspicious,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation[@SimpleName='Retry']
@@ -699,7 +697,7 @@ public class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('reactor.core.publisher.Hooks#onOperatorDebug()')]
@@ -735,7 +733,7 @@ public class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,confusing" type="String" description="classification"/>
+            <property name="tags" value="confusing,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[pmd-java:matchesSig('org.springframework.http.client.HttpComponentsClientHttpRequestFactory#setHttpClient(_)')][VariableAccess/@Name =
@@ -789,7 +787,7 @@ class Good {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,confusing,suspicious" type="String" description="classification"/>
+            <property name="tags" value="confusing,jpinpoint-rule,suspicious" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall[pmd-java:typeIs("org.apache.http.HttpHost")][ArgumentList[@Size=1]]
@@ -829,8 +827,7 @@ class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,confusing,suspicious" type="String"
-                      description="classification"/>
+            <property name="tags" value="confusing,jpinpoint-rule,performance,suspicious" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall[pmd-java:typeIs("org.springframework.boot.web.client.ClientHttpRequestFactorySupplier")]
@@ -892,8 +889,7 @@ and use it to replace the bad line in Bad example:
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,bad-practice" type="String"
-                      description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //LocalVariableDeclaration//ConstructorCall[pmd-java:typeIs('org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor')]
@@ -937,7 +933,7 @@ and use it to replace the bad line in Bad example:
     </description>
     <priority>3</priority>
     <properties>
-        <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+        <property name="tags" value="cpu,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
         <property name="xpath">
             <value><![CDATA[
 //ConstructorCall[pmd-java:typeIs('org.springframework.http.client.BufferingClientHttpRequestFactory')]
@@ -982,7 +978,7 @@ public class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="io,jpinpoint-rule,performance,sustainability-low,resilience" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: use of field, local var and return statement :)
@@ -1107,7 +1103,7 @@ class GoodStyle {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration//LocalVariableDeclaration/ClassType[pmd-java:typeIs('io.axual.client.producer.Producer')]
@@ -1158,7 +1154,7 @@ public class AxualProducerBad {
         </description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 (: any on-method: onRetry, onError, .. :)
@@ -1210,8 +1206,7 @@ public class Foo {
         </description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,bad-practice" type="String"
-                      description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //FieldDeclaration[PrimitiveType/@Kind='int']/VariableDeclarator
@@ -1268,7 +1263,7 @@ class AvoidHardcodedConnectionConfig {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassType[pmd-java:typeIs('org.springframework.ws.soap.saaj.SaajSoapMessageFactory')

--- a/src/main/resources/category/java/spring.xml
+++ b/src/main/resources/category/java/spring.xml
@@ -17,7 +17,7 @@
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,confusing,suspicious,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="confusing,data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -99,7 +99,7 @@ class Good {
             to use in the render request scope. (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[
@@ -151,7 +151,7 @@ public ModelAndView initialOverviewRender(RenderRequest request, String viewName
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -193,7 +193,7 @@ public class AvoidSpringApplicationContextRecreation {
             redirect:/redirectUrl?someAttribute={someAttribute}.</description>
         <priority>1</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ReturnStatement//InfixExpression[@Operator = "+"]
@@ -325,7 +325,7 @@ public class DoodleController {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[
@@ -359,7 +359,7 @@ public void validateDetails(ActionRequest request, ModelMap modelMap) {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation[pmd-java:typeIs('org.springframework.cache.annotation.Cacheable')]/AnnotationMemberList/MemberValuePair[@Name='key']
@@ -393,7 +393,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,multi-threading,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,jpinpoint-rule,multi-threading,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation[
@@ -428,7 +428,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,bad-practice,bad-practice" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ConstructorCall[
@@ -470,7 +470,7 @@ class Good {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,bad-practice" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,cpu,jpinpoint-rule,performance,sustainability-low" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImplementsList/ClassType[pmd-java:typeIs("org.springframework.cache.interceptor.KeyGenerator")]
@@ -538,7 +538,7 @@ public class Good implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tag" value="jpinpoint-rule,performance,bad-practice" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,jpinpoint-rule,performance" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //Annotation[
@@ -577,7 +577,7 @@ class Foo {
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,bad-practice,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ImplementsList/ClassType[pmd-java:typeIs("org.springframework.cache.interceptor.KeyGenerator")]
@@ -630,7 +630,7 @@ class GoodCacheKeyGenerator implements KeyGenerator {
             (jpinpoint-rules)</description>
         <priority>5</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance,suspicious,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="data-mix-up,jpinpoint-rule,suspicious" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //MethodDeclaration[pmd-java:hasAnnotation('org.springframework.cache.annotation.Cacheable')]
@@ -679,7 +679,7 @@ class MyObject {
             (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,confusing,bad-practice,data-mix-up" type="String" description="classification"/>
+            <property name="tags" value="bad-practice,confusing,data-mix-up,jpinpoint-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
 //ClassDeclaration[

--- a/src/main/resources/category/java/sql.xml
+++ b/src/main/resources/category/java/sql.xml
@@ -13,7 +13,7 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -44,7 +44,7 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -131,7 +131,7 @@
             (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,performance" type="String" description="classification"/>
+            <property name="tags" value="cpu,io,jpinpoint-rule,memory,performance,sustainability-high" type="String" description="classification"/>
             <property name="xpath">
                 <value>
                     <![CDATA[


### PR DESCRIPTION
# common.xml
* `<!-- complex rule TODO ImplementEqualsHashCodeOnValueObjects -->`
* AvoidCalendar is missing in `pmd7`?
* MissingEqualsAndHashCodeWithGetterSetter not in pmd7, also no new tags?

# common_std.xml
* AvoidUnusedAssignments is missing in `pmd7` (todo)

ImplementEqualsHashCodeOnValueObjects - is missing? TODO?

AvoidCalendar, Sonar has a rule to use java.time instead of Calendar etc. ; this rule seems unnecessary, however, not sure, it may be useful in IntelliJ, what do you think?

I added MissingEqualsAndHashCodeWithGetterSetter, correctness, not performance nor sustainability in my view