### PR TITLE
pmd7 fix request #389 fix + added unit test to check combination of @ConfigurationProperties and Lombok @Setter

### DIFF
--- a/src/main/resources/category/java/concurrent.xml
+++ b/src/main/resources/category/java/concurrent.xml
@@ -402,8 +402,7 @@ public class RootController {
    (: if @NotThreadSafe no checking :)
    and not(pmd-java:hasAnnotation('net.jcip.annotations.NotThreadSafe'))
    (: ConfigurationProperties assumed executed only once, no violation, except if Lombok Setter :)
-   and not(pmd-java:hasAnnotation('org.springframework.boot.context.properties.ConfigurationProperties'))
-   and not(pmd-java:hasAnnotation('lombok.Setter'))]
+   and not(pmd-java:hasAnnotation('org.springframework.boot.context.properties.ConfigurationProperties') and not(pmd-java:hasAnnotation('lombok.Setter')))]
 (: non-final and non-volatile fields :)
 //FieldDeclaration[
 
@@ -551,8 +550,7 @@ class BadMutebleTypes {
    (: if @NotThreadSafe no checking :)
    and not(pmd-java:hasAnnotation('net.jcip.annotations.NotThreadSafe'))
    (: ConfigurationProperties assumed executed only once, no violation, except if Lombok Setter :)
-   and not(pmd-java:hasAnnotation('org.springframework.boot.context.properties.ConfigurationProperties'))
-   and not(pmd-java:hasAnnotation('lombok.Setter'))]
+   and not(pmd-java:hasAnnotation('org.springframework.boot.context.properties.ConfigurationProperties') and not(pmd-java:hasAnnotation('lombok.Setter')))]
 (: any method call:)
 //MethodCall[
     (: class extends a base class :)

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableFieldsInSharedObjects.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableFieldsInSharedObjects.xml
@@ -477,4 +477,30 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Avoid unguarded mutable fields in shared objects. Not for ConfigurationProperties, unless also Lombok Setter, Issue #389</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>10,11</expected-linenumbers>
+        <code><![CDATA[
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import my.app.*;
+
+@ConfigurationProperties("my.app")
+@Component
+@Setter
+public class Issue389bad {
+    private String url;
+    private String token;
+}
+
+@ConfigurationProperties("my.app")
+public class Issue389good {
+    private String url;
+    private String token;
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableFieldsInSharedObjects.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableFieldsInSharedObjects.xml
@@ -491,14 +491,14 @@ import my.app.*;
 @Component
 @Setter
 public class Issue389bad {
-    private String url;
-    private String token;
+    private String url; // bad, ConfigurationProperties but also Lombok Setter
+    private String token; // bad, ConfigurationProperties but also Lombok Setter
 }
 
 @ConfigurationProperties("my.app")
 public class Issue389good {
-    private String url;
-    private String token;
+    private String url; // good, ConfigurationProperties
+    private String token; // good, ConfigurationProperties
 }
         ]]></code>
     </test-code>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableInheritedFieldsInSharedObjects.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/concurrent/xml/AvoidUnguardedMutableInheritedFieldsInSharedObjects.xml
@@ -105,4 +105,35 @@ class SynchronizedTryout {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Avoid unguarded mutable fields in shared objects. Not for ConfigurationProperties, unless also Lombok Setter, Issue #389</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>19</expected-linenumbers>
+        <code><![CDATA[
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import my.app.*;
+
+@ConfigurationProperties("my.app")
+@Component
+public class Issue389good extends SynchronizedTryout {
+    public void mutateMap(String key, String val) {
+        map.put(key, val); // good, ConfigurationProperties
+    }
+}
+
+@ConfigurationProperties("my.app")
+@Component
+@Setter
+public class Issue389bad extends SynchronizedTryout {
+    public void mutateMap(String key, String val) {
+        map.put(key, val); // bad, ConfigurationProperties but also Lombok Setter
+    }
+}
+class SynchronizedTryout {
+    protected final Map map;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Question: is this also a valid check for `AvoidUnguardedMutableInheritedFieldsInSharedObjects`? Or should be removed? 