### PR TITLE
pmd7 fix request #392 AvoidImplicitlyRecompilingRegex assume external constants bad?

### DIFF
--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -168,12 +168,23 @@ and not (preceding-sibling::SwitchLabel[@Default=true()])]
     or pmd-java:matchesSig('java.lang.String#matches(java.lang.String)')
     or pmd-java:matchesSig('java.nio.file.FileSystem#getPathMatcher(java.lang.String)')
 ]
-/ArgumentList/*[1][(self::StringLiteral and string-length(@Image) > 5 and
-(matches(@Image, '[\.\$\|\(\)\[\]\{\}\^\?\*\+\\]+')))
-or
-self::VariableAccess and @Name=ancestor::ClassBody/FieldDeclaration/VariableDeclarator[StringLiteral[string-length(@Image) > 5 and
-(matches(@Image, '[\.\$\|\(\)\[\]\{\}\^\?\*\+\\]+'))] or not(StringLiteral)]/VariableId/@Name]
-]]></value>
+/ArgumentList/*[1][
+    (: external references are assumed ok, e.g. Constants.SEP :)
+    self::FieldAccess[not(TypeExpression)]
+    or (self::StringLiteral
+        and string-length(@Image) > 5
+        and (matches(@Image, '[\.\$\|\(\)\[\]\{\}\^\?\*\+\\]+'))
+    )
+    or (self::VariableAccess
+        and @Name=ancestor::ClassBody/FieldDeclaration/VariableDeclarator[
+             StringLiteral[
+                 string-length(@Image) > 5
+                 and (matches(@Image, '[\.\$\|\(\)\[\]\{\}\^\?\*\+\\]+'))
+             ] or not(StringLiteral)
+        ]/VariableId/@Name
+    )
+]
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidImplicitlyRecompilingRegex.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidImplicitlyRecompilingRegex.xml
@@ -275,14 +275,15 @@ public class Bar {
 
     <test-code>
         <description>violation: Avoid implicit recompiling of regular expressions, assume external fields as good</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,8</expected-linenumbers>
         <code><![CDATA[
+import my.app.*;
 public class Try {
     private static final String SMALL = "-.";
     private static final String LARGE = "------.-";
     public static void foo(String query) {
-        query.split(Constants.SEP); //assumed good, external
+        query.split(Constants.SEP); //assumed bad, external
         query.split(SMALL); //good
         query.split(LARGE); //bad
     }
@@ -304,6 +305,22 @@ class Foo {
                 .findFirst()
                 .toString()
                 .replaceAll("\\s+", "-"); // bad, missing violation
+    }
+}
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: missing case in AvoidImplicitlyRecompilingRegex #xxx</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import my.app.*;
+class Foo {
+      public static String checkUser(String userId){
+        if (!userId.matches(FooConstant.USER_REGEX)) { // bad, external, assume USER_REGEX is not simple
+            throw new RuntimeException("Invalid userId");
+        }
     }
 }
             ]]></code>


### PR DESCRIPTION
assume constants for regexps are not simple

For discussion: pmd6 rule had a hit, but that might be a bug as in unit tests other Contant.SEP was assumed good, but should we maybe turn it around? If it is a constant assume it to be not a simple regex? 

```java
import my.app.FooConstant;
class Foo {
      public static String checkUser(String userId){
        if (!userId.matches(FooConstant.USER_REGEX)) { // bad, missing violation or assume good?
            throw new RuntimeException("Invalid userId");
        }
    }
}
```

This was here already, should we turn this into "assumed bad, external"?
```java
public class Try {
    private static final String SMALL = "-.";
    private static final String LARGE = "------.-";
    public static void foo(String query) {
        query.split(Constants.SEP); //assumed good, external
        query.split(SMALL); //good
        query.split(LARGE); //bad
    }
}
```

note: 
```java
public static final String USER_REGEX = "^USR\\d+$";
```