### PR TITLE
pmd7 fix request #411 LetFieldsMeetSerializable double hits

### DIFF
--- a/src/main/resources/category/java/common_std.xml
+++ b/src/main/resources/category/java/common_std.xml
@@ -231,22 +231,32 @@ import static com.co.corporate.Constants.GREAT; // good
             <property name="tags" value="jpinpoint-rule,pitfall,replaces-sonar-rule" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
-//ClassDeclaration[pmd-java:typeIs('java.io.Serializable')
-(: Throwable is the exception, except RemoteException :)
-and not(pmd-java:typeIs('java.lang.Throwable') and not(pmd-java:typeIs('java.rmi.RemoteException')))]
 (: non-transient, non-static, non-primitive fields :)
-//FieldDeclaration[not(pmd-java:modifiers() = ('transient', 'static'))]
-[not(.//PrimitiveType)]
-[ClassType[not(pmd-java:typeIs('java.io.Serializable'))]]
-(: and can be resolved :)
-[ClassType[pmd-java:typeIs('java.lang.Object')]]
-(: if has type args, type args which are not serializable like List<String, Thread>):)
-[not(exists(.//TypeArguments))
-    or exists(.//TypeArguments/ClassType[not(pmd-java:typeIs('java.io.Serializable'))
-                                         (: and can be resolved :)
-                                         and pmd-java:typeIs('java.lang.Object')]
+//FieldDeclaration[
+     not(pmd-java:modifiers() = ('transient', 'static'))
+     and not(.//PrimitiveType)
+     and ClassType[not(pmd-java:typeIs('java.io.Serializable'))]
+     (: and can be resolved :)
+     and ClassType[pmd-java:typeIs('java.lang.Object')]
+     (: if has type args, type args which are not serializable like List<String, Thread>) :)
+     and (
+           not(exists(.//TypeArguments))
+           or exists(.//TypeArguments/ClassType[
+                                  not(pmd-java:typeIs('java.io.Serializable'))
+                                  (: and can be resolved :)
+                                  and pmd-java:typeIs('java.lang.Object')
+                              ]
+           )
     )
-]                ]]></value>
+    and ancestor::ClassDeclaration[pmd-java:typeIs('java.io.Serializable')
+                       (: Throwable is the exception, except RemoteException :)
+                       and not(
+                                 pmd-java:typeIs('java.lang.Throwable')
+                                 and not(pmd-java:typeIs('java.rmi.RemoteException'))
+                           )
+                   ]
+]
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common_std/xml/LetFieldsMeetSerializable.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common_std/xml/LetFieldsMeetSerializable.xml
@@ -70,6 +70,7 @@ class SerializableOther implements Serializable {
     <test-code>
         <description>Fix Request: LetFieldsMeetSerializable has false positives #231</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
         <code><![CDATA[
 import java.lang.*;
 import java.util.*;
@@ -79,6 +80,29 @@ import lombok.*;
 class SomeDTO implements Serializable {
     private List<@NonNull Serializable> listGood; // false positive, actually good
     private List<@NonNull Object> listBad; // bad
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Fix Request: LetFieldsMeetSerializable has multiple hits #411</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import java.lang.*;
+import java.util.*;
+import java.io.*;
+
+class SomeDTO implements Serializable {
+   private MyBank myBank;
+
+    public static class MyBank implements Serializable {
+        private MyCode code; // bad <-- two hits on this line, one expected
+    }
+
+    private static class MyCode {
+        private String code;
+    }
 }
      ]]></code>
     </test-code>


### PR DESCRIPTION
avoid double hits by using ancestor:: instead of //ClassDeclaration (double hits on nested classes)