### PR TITLE
Fix variable matching in constructor assignment expressions

### DIFF
--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -4516,7 +4516,7 @@ class Good {
     [matches(upper-case(@Name), 'TIMEOUT|DURATIONOUT') or (contains(upper-case(@Name), 'MAX') and contains(upper-case(@Name), 'ROUTE'))]
 ]
 [NumericLiteral or
-    (VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//AssignmentExpression/*[1]/@Name
+    (VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//AssignmentExpression[NumericLiteral]/*[1]/@Name
     and not(VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//FormalParameter[pmd-java:hasAnnotation('org.springframework.beans.factory.annotation.Value')]/VariableId/@Name))
 ]
 ]]></value>

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -1214,7 +1214,7 @@ public class Foo {
     [matches(upper-case(@Name), 'TIMEOUT|DURATIONOUT') or (contains(upper-case(@Name), 'MAX') and contains(upper-case(@Name), 'ROUTE'))]
 ]
 [NumericLiteral or
-    (VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//AssignmentExpression/*[1]/@Name
+    (VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//AssignmentExpression[NumericLiteral]/*[1]/@Name
     and not(VariableId/@Name=ancestor::ClassBody//ConstructorDeclaration//FormalParameter[pmd-java:hasAnnotation('org.springframework.beans.factory.annotation.Value')]/VariableId/@Name))
 ]
 ]]></value>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/AvoidHardcodedConnectionConfig.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/remoting/xml/AvoidHardcodedConnectionConfig.xml
@@ -71,4 +71,18 @@ public final class Issue398 {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>no violation: AvoidHardcodedConnectionConfig: Issue417</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Issue417 {
+    private final int readTimeout; // <--- false positive
+
+    Issue417() {
+        readTimeout = Configuration.getReadTimeout();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Updated XPath expressions in remoting rules to accurately match VariableId instances within NumericLiteral contexts in constructor assignments. Added a test case to ensure proper handling of hardcoded connection configurations and to avoid false positives in issue #417.