### PR TITLE
 fix issue356 - False positive in AvoidExposingMutableRecordState

### DIFF
--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -219,12 +219,13 @@ switch (type) {
 
     <rule name="AvoidExposingMutableRecordState"
           language="java"
-          message="Avoid exposing mutable state of the record. Use copyOf in the compact constructor."
+          message="Avoid exposing mutable state of the record. Use copyOf in the (compact) constructor."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
 
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#voedos06">
-        <description>Problem: Internal state can be modified from outside of the record, through the implicit accessor method or by the caller of the constructor. Risk of thread-unsafety.
-            Solution: Use the record compact constructor to defensively copy the (possibly) mutable object such as a List, Set or Map, e.g. with List.copyOf().
+        <description>Problem: Internal state can be modified from outside the record, through the implicit accessor method or by the caller of the constructor. Risk of thread-unsafety.
+            Solution: Use the record compact constructor to defensively copy the (possibly) mutable object such as a List, Set or Map, e.g. with List.copyOf(). Make sure
+            to avoid NullPointerExceptions for null values in List.copyOf() methods. Beware that contained objects in collections can itself be mutable.
         (jpinpoint-rules)</description>
         <priority>3</priority>
         <properties>
@@ -232,9 +233,9 @@ switch (type) {
             <property name="xpath">
                 <value><![CDATA[
 //RecordDeclaration//RecordComponent/ClassType[(pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map'))
-    and not(../VariableId/@Name = ancestor::RecordDeclaration/RecordBody/CompactConstructorDeclaration
-        //AssignmentExpression[VariableAccess/@Name = .//MethodCall[@MethodName='copyOf']
-            /ArgumentList/VariableAccess/@Name]/VariableAccess/@Name)
+    and not(../VariableId/@Name = ancestor::RecordDeclaration/RecordBody/(CompactConstructorDeclaration|ConstructorDeclaration)
+        //AssignmentExpression[(VariableAccess|FieldAccess)/@Name = .//MethodCall[contains(lower-case(@MethodName), 'copyof')]
+            /ArgumentList/(VariableAccess|FieldAccess)/@Name]/(VariableAccess|FieldAccess)/@Name)
 ]/..
 ]]></value>
             </property>
@@ -246,7 +247,7 @@ record BadRecord(String name, List<String> list) {
 
 record GoodRecord(String name, List<String> list) {
     public GoodRecord {
-        list = List.copyOf(list);
+        list = list != null ? List.copyOf(list) : List.of();
     }
 }
             ]]>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -1712,8 +1712,9 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
 
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#voedos06">
-        <description>Problem: Internal state can be modified from outside of the record, through the implicit accessor method or by the caller of the constructor. Risk of thread-unsafety.
-            Solution: Use the record compact constructor to defensively copy the (possibly) mutable object such as a List, Set or Map, e.g. with List.copyOf().
+        <description>Problem: Internal state can be modified from outside the record, through the implicit accessor method or by the caller of the constructor. Risk of thread-unsafety.
+            Solution: Use the record compact constructor to defensively copy the (possibly) mutable object such as a List, Set or Map, e.g. with List.copyOf(). Make sure
+            to avoid NullPointerExceptions for null values in List.copyOf() methods. Beware that contained objects in collections can itself be mutable.
         </description>
         <priority>3</priority>
         <properties>
@@ -1735,7 +1736,7 @@ record BadRecord(String name, List<String> list) {
 
 record GoodRecord(String name, List<String> list) {
     public GoodRecord {
-        list = List.copyOf(list);
+        list = list != null ? List.copyOf(list) : List.of();
     }
 }
             ]]>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -1708,7 +1708,7 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
 
     <rule name="AvoidExposingMutableRecordState"
           language="java"
-          message="Avoid exposing mutable state of the record. Use copyOf in the compact constructor."
+          message="Avoid exposing mutable state of the record. Use copyOf in the (compact) constructor."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
 
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#voedos06">
@@ -1722,9 +1722,9 @@ Set<YourEnumType> set = EnumSet.allOf(YourEnumType.class);
             <property name="xpath">
                 <value><![CDATA[
 //RecordDeclaration//RecordComponent/ClassType[(pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map'))
-    and not(../VariableId/@Name = ancestor::RecordDeclaration/RecordBody/CompactConstructorDeclaration
-        //AssignmentExpression[VariableAccess/@Name = .//MethodCall[@MethodName='copyOf']
-            /ArgumentList/VariableAccess/@Name]/VariableAccess/@Name)
+    and not(../VariableId/@Name = ancestor::RecordDeclaration/RecordBody/(CompactConstructorDeclaration|ConstructorDeclaration)
+        //AssignmentExpression[(VariableAccess|FieldAccess)/@Name = .//MethodCall[contains(lower-case(@MethodName), 'copyof')]
+            /ArgumentList/(VariableAccess|FieldAccess)/@Name]/(VariableAccess|FieldAccess)/@Name)
 ]/..
 ]]></value>
             </property>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidExposingMutableRecordState.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidExposingMutableRecordState.xml
@@ -4,9 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description>violation: Avoid exposing mutable record state, use copyOf in the compact constructor.</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>8, 11, 20</expected-linenumbers>
+        <description>violation: Avoid exposing mutable record state, use copyOf in the (compact) constructor.</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>8, 11, 20, 23</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 import static java.util.List.copyOf;
@@ -28,6 +28,13 @@ record GoodRecord(String name, List<String> list) {
 }
 
 record SetRecord(String name, Set<String> set) { // bad 3
+}
+
+record BadRecordNonCompact(String name, List<String> list) { // bad 4
+  public BadRecordNonCompact(String name, List<String> list) {
+    this.name = name;
+    this.list = order(list); // bad, no copy
+  }
 }
 
 record MapRecord(String name, Map<String,String> map) {
@@ -75,6 +82,49 @@ record GoodRecordIf(String name, List<String> list) {
         }
         else {
             list = List.copyOf(list);
+        }
+    }
+}
+
+record GoodRecordNonCompact(String name, List<String> list) {
+    public GoodRecordNonCompact(String name, List<String> list) {
+        this.name = name;
+        if (list == null) {
+            this.list = null; // keep the state null when null is supplied.
+        }
+        else {
+            this.list = List.copyOf(list);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>violation: Avoid exposing mutable record state, use copyOf in constructor via util method.</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+
+public record MyRecord(List<SomeOtherRecord> otherRecords) { // bad, no copy
+    public MyRecord(List<OtherRecord> otherRecords) {
+        this.otherRecords = nonNull(otherRecords);
+    }
+    private static <T> List<T> nonNull(List<T> source) {
+        return source == null ? List.of() : source;
+    }
+}
+
+public record MyRecord(List<SomeOtherRecord> otherRecords) { // good, copy
+    public MyRecord(List<OtherRecord> otherRecords) {
+        this.otherRecords = nullSafeCopyOf(otherRecords);
+    }
+
+    private static <T> List<T> nullSafeCopyOf(List<T> source) {
+        if (source != null) {
+            return List.copyOf(source);
+        } else {
+            return List.of();
         }
     }
 }


### PR DESCRIPTION
Note that this example uses the non-compact record constructor. Fixed that as well.

The fix will check for assignment methods that contain 'copyOf'. So if a utility method is used (also from other class), make sure to include copyOf in the name.