### PR TITLE
new rule #567: InitializeComparatorOnlyOnce

### DIFF
--- a/docs/JavaCodePerformance.md
+++ b/docs/JavaCodePerformance.md
@@ -2654,6 +2654,75 @@ Note the use of explicit (Integer) cast to call the correct overloaded remove(In
 Suggested fix: create a category id variable of type Integer before the if statement so no further implicit boxing is done.  
 **Tip:** enable the compiler check on auto boxing/unboxing in eclipse.
 
+#### UE03
+
+**Observation: Creating new `Comparator` instances repeatedly**, e.g. in methods like `compareTo()` or collection sort operations.  
+**Problem:** Performance penalty from repeatedly creating objects, increasing garbage collection pressure and CPU usage, especially in frequently called methods or loops.  
+**Solution:** Initialize `Comparator` instances as `static final` fields. Make sure they don't use external state and are thread-safe.  
+
+Example 1: Creating a new Comparator in compareTo method:
+
+```java
+public int compareTo(Person other) {
+    return Comparator.comparing(Person::getFirstName)  // Creates new Comparator and inner lambda's each time
+            .thenComparing(Person::getLastName)
+            .compare(this, other);
+}
+```
+
+The Comparator is unnecessarily created on each method invocation. Initialize it as a static final field instead.
+
+Example 2: Proper initialization as static final field:
+
+```java
+private static final Comparator<Person> PERSON_COMPARATOR = 
+    Comparator.comparing(Person::getFirstName)
+            .thenComparing(Person::getLastName);
+
+public int compareTo(Person other) {
+    return PERSON_COMPARATOR.compare(this, other);  // Reuses existing Comparator
+}
+```
+
+Example 3: Creating a new Comparator for each TreeSet:
+```java
+public class PersonRepository {
+    public Set<Person> getPersonsSortedByName() {
+        return new TreeSet<>(Comparator.comparing(Person::getName));
+    }
+    
+    public List<Person> getSortedPersons() {
+        List<Person> persons = getPersons();
+        persons.sort(Comparator.comparing(Person::getName));
+        return persons;
+    }
+}
+```
+
+Suggested improvement (has less impact than example 2 where compareTo method is called many times, this is per collection creation or sort call only):
+
+```java
+public class PersonRepository {
+    private static final Comparator<Person> PERSON_BY_NAME_COMPARATOR = 
+        Comparator.comparing(Person::getName);
+    
+    public Set<Person> getPersonsSortedByName() {
+        return new TreeSet<>(PERSON_BY_NAME_COMPARATOR);
+    }
+    
+    public List<Person> getSortedPersons() {
+        List<Person> persons = getPersons();
+        persons.sort(PERSON_BY_NAME_COMPARATOR);
+        return persons;
+    }
+}
+```
+
+Note that local one-time Comparators may be acceptable in specific cases where the comparison is used only once or the logic needs to be dynamic.
+However, for frequently used or standard comparison operations, always use static final fields to avoid unnecessary object creation.
+
+**Rule name**: InitializeComparatorOnlyOnce
+
 Inefficient memory usage
 ------------------------
 

--- a/docs/JavaCodePerformance.md
+++ b/docs/JavaCodePerformance.md
@@ -2657,9 +2657,11 @@ Suggested fix: create a category id variable of type Integer before the if state
 #### UE03
 
 **Observation: Creating new `Comparator` instances repeatedly**, e.g. in methods like `compareTo()` or collection sort operations.  
-**Problem:** Performance penalty from repeatedly creating objects, increasing garbage collection pressure and CPU usage, especially in frequently called methods or loops.  
-**Solution:** Initialize `Comparator` instances as `static final` fields. Make sure they don't use external state and are thread-safe.  
+**Problem:** Repeatedly creating the same object causes a performance penalty: it increases garbage collection pressure and CPU usage, 
+especially in frequently called methods or loops.  
+**Solution:** Initialize `Comparator` instances once as `static final` fields and reuse these instances.
 
+**Examples:**  
 Example 1: Creating a new Comparator in compareTo method:
 
 ```java
@@ -2717,10 +2719,8 @@ public class PersonRepository {
     }
 }
 ```
-
-Note that local one-time Comparators may be acceptable in specific cases where the comparison is used only once or the logic needs to be dynamic.
-However, for frequently used or standard comparison operations, always use static final fields to avoid unnecessary object creation.
-
+**Note:** local one-time Comparators may be acceptable in specific cases where the comparison is used only once or the logic needs to be dynamic.
+However, for frequently used or standard comparison operations, always use static final fields to avoid unnecessary object creation.  
 **Rule name**: InitializeComparatorOnlyOnce
 
 Inefficient memory usage

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -1761,9 +1761,9 @@ class Foo {
           language="java"
           message="Avoid creating Comparator instances repeatedly. Initialize them as static final fields instead."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md">
+          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#UE03">
         <description>Problem: Creating Comparator instances repeatedly in methods like compareTo or sort calls is inefficient.&#13;
-            Solution: Initialize the Comparator as a static final field when not using external state and is thread safe.
+            Solution: Initialize the Comparator once as a static final field and reuse.
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -1785,7 +1785,7 @@ class Foo {
         pmd-java:typeIs('java.util.Comparator')
     ])
     (: used in non-static-final way :)
-    and not(ancestor::ClassBody[1]/FieldDeclaration[pmd-java:modifiers() = ('final','static')])
+    and not(ancestor::FieldDeclaration[pmd-java:modifiers() = ('final') and pmd-java:modifiers() = ('static')])
 ]
             ]]></value>
             </property>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -1757,6 +1757,66 @@ class Foo {
         </example>
     </rule>
 
+    <rule name="InitializeComparatorOnlyOnce"
+          language="java"
+          message="Avoid creating Comparator instances repeatedly. Initialize them as static final fields instead."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md">
+        <description>Problem: Creating Comparator instances repeatedly in methods like compareTo or sort calls is inefficient.&#13;
+            Solution: Initialize the Comparator as a static final field when not using external state and is thread safe.
+        (jpinpoint-rules)</description>
+        <priority>2</priority>
+        <properties>
+            <property name="tags" value="jpinpoint-rule,sustainability-medium,cpu" type="String" description="classification"/>
+            <property name="xpath">
+                <value><![CDATA[
+//MethodCall[
+    (pmd-java:matchesSig('java.util.Comparator#comparing(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingInt(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingDouble(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')
+      or pmd-java:matchesSig('java.util.Comparator#nullsFirst(_)')
+      or pmd-java:matchesSig('java.util.Comparator#nullsLast(_)')
+    )
+    (: not chained: AST is backwards with first call last element :)
+    and not(MethodCall[pmd-java:typeIs('java.util.Comparator')])
+    (: not used as argument to another Comparator method :)
+    and not(parent::ArgumentList/parent::MethodCall[
+        pmd-java:typeIs('java.util.Comparator')
+    ])
+    (: used in non-static-final way :)
+    and not(ancestor::ClassBody[1]/FieldDeclaration[pmd-java:modifiers() = ('final','static')])
+]
+            ]]></value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class BadPerson implements Comparable<Person> {
+    @Override
+    public int compareTo(@NotNull Person o) {
+        return Comparator.comparing(Person::getFirstName)  // Bad: Creates new Comparator instance on each invocation
+                .thenComparing(Person::getLastName)
+                .thenComparingInt(Person::getAge)
+                .compare(this, o);
+    }
+}
+
+public class GoodPerson implements Comparable<Person> {
+    private static final Comparator<Person> COMPARE_AGE_LAST_FIRST =
+        Comparator.comparing(Person::getFirstName)
+            .thenComparing(Person::getLastName)
+            .thenComparingInt(Person::getAge);
+
+    @Override
+    public int compareTo(@NotNull Person o) {
+        return COMPARE_AGE_LAST_FIRST.compare(this, o);     // Good: Comparator initialized once as static final field
+    }
+}
+        ]]>
+        </example>
+    </rule>
+
     <rule name="MDCPutWithoutRemove"
           message="MDC put is used without finally remove."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
@@ -6199,14 +6259,15 @@ class Good {
 /../..//MethodDeclaration[@Name='generate']
 (: select all variables in block, *[2] to select part after assignment :)
 /Block//
-
   (ReturnStatement|LocalVariableDeclaration/VariableDeclarator/*[2])
   (: where name matches the third Object... parameter name of generate method :)
   //VariableAccess[
      @Name = ancestor::MethodDeclaration//FormalParameter[3]/VariableId/@Name
      and not(
+        (: used with SimpleKey :)
+        ancestor::ConstructorCall//ClassType[pmd-java:typeIs("org.springframework.cache.interceptor.SimpleKey")]
         (: without an explicit cast :)
-        exists(../../..//CastExpression)
+        or exists(../../..//CastExpression)
         (: - exclude if in an if-block checking params.length to do error logging or so - :)
         or exists(ancestor::IfStatement//FieldAccess[@Name = 'length'])
      )
@@ -6221,11 +6282,12 @@ class Good {
    @Name = ancestor::ForeachStatement/LocalVariableDeclaration//VariableId/@Name
    and ../../MethodCall[@MethodName = 'toString']
 ]
-    ]]></value>
+           ]]></value>
             </property>
         </properties>
         <example>
             <![CDATA[
+import java.lang.reflect.Method;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.util.StringUtils;
 

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -1777,6 +1777,7 @@ class Foo {
       or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')
       or pmd-java:matchesSig('java.util.Comparator#nullsFirst(_)')
       or pmd-java:matchesSig('java.util.Comparator#nullsLast(_)')
+      or pmd-java:matchesSig('java.util.Comparator#reversed()')
     )
     (: not chained: AST is backwards with first call last element :)
     and not(MethodCall[pmd-java:typeIs('java.util.Comparator')])
@@ -1787,7 +1788,7 @@ class Foo {
     (: used in non-static-final way :)
     and not(ancestor::FieldDeclaration[pmd-java:modifiers() = ('final') and pmd-java:modifiers() = ('static')])
 ]
-            ]]></value>
+]]></value>
             </property>
         </properties>
         <example>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -1771,7 +1771,7 @@ class Foo {
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[
-    (pmd-java:matchesSig('java.util.Comparator#comparing(_)')
+    (pmd-java:matchesSig('java.util.Comparator#comparing(_*)')
       or pmd-java:matchesSig('java.util.Comparator#comparingInt(_)')
       or pmd-java:matchesSig('java.util.Comparator#comparingDouble(_)')
       or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2442,6 +2442,7 @@ class IterationsBetter {
       or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')
       or pmd-java:matchesSig('java.util.Comparator#nullsFirst(_)')
       or pmd-java:matchesSig('java.util.Comparator#nullsLast(_)')
+      or pmd-java:matchesSig('java.util.Comparator#reversed()')
     )
     (: not chained: AST is backwards with first call last element :)
     and not(MethodCall[pmd-java:typeIs('java.util.Comparator')])
@@ -2452,7 +2453,7 @@ class IterationsBetter {
     (: used in non-static-final way :)
     and not(ancestor::FieldDeclaration[pmd-java:modifiers() = ('final') and pmd-java:modifiers() = ('static')])
 ]
-            ]]></value>
+]]></value>
             </property>
         </properties>
         <example>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2450,7 +2450,7 @@ class IterationsBetter {
         pmd-java:typeIs('java.util.Comparator')
     ])
     (: used in non-static-final way :)
-    and not(ancestor::ClassBody[1]/FieldDeclaration[pmd-java:modifiers() = ('final','static')])
+    and not(ancestor::FieldDeclaration[pmd-java:modifiers() = ('final') and pmd-java:modifiers() = ('static')])
 ]
             ]]></value>
             </property>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2426,9 +2426,9 @@ class IterationsBetter {
           language="java"
           message="Avoid creating Comparator instances repeatedly. Initialize them as static final fields instead."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${doc_root}/JavaCodePerformance.md">
+          externalInfoUrl="${doc_root}/JavaCodePerformance.md#UE03">
         <description>Problem: Creating Comparator instances repeatedly in methods like compareTo or sort calls is inefficient.&#13;
-            Solution: Initialize the Comparator as a static final field when not using external state and is thread safe.
+            Solution: Initialize the Comparator once as a static final field and reuse.
         </description>
         <priority>2</priority>
         <properties>

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2436,7 +2436,7 @@ class IterationsBetter {
             <property name="xpath">
                 <value><![CDATA[
 //MethodCall[
-    (pmd-java:matchesSig('java.util.Comparator#comparing(_)')
+    (pmd-java:matchesSig('java.util.Comparator#comparing(_*)')
       or pmd-java:matchesSig('java.util.Comparator#comparingInt(_)')
       or pmd-java:matchesSig('java.util.Comparator#comparingDouble(_)')
       or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2422,5 +2422,63 @@ class IterationsBetter {
             ]]>
         </example>
     </rule>
+    <rule name="InitializeComparatorOnlyOnce"
+          language="java"
+          message="Avoid creating Comparator instances repeatedly. Initialize them as static final fields instead."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${doc_root}/JavaCodePerformance.md">
+        <description>Problem: Creating Comparator instances repeatedly in methods like compareTo or sort calls is inefficient.&#13;
+            Solution: Initialize the Comparator as a static final field when not using external state and is thread safe.
+        </description>
+        <priority>2</priority>
+        <properties>
+            <property name="tags" value="jpinpoint-rule,sustainability-medium,cpu" type="String" description="classification"/>
+            <property name="xpath">
+                <value><![CDATA[
+//MethodCall[
+    (pmd-java:matchesSig('java.util.Comparator#comparing(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingInt(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingDouble(_)')
+      or pmd-java:matchesSig('java.util.Comparator#comparingLong(_)')
+      or pmd-java:matchesSig('java.util.Comparator#nullsFirst(_)')
+      or pmd-java:matchesSig('java.util.Comparator#nullsLast(_)')
+    )
+    (: not chained: AST is backwards with first call last element :)
+    and not(MethodCall[pmd-java:typeIs('java.util.Comparator')])
+    (: not used as argument to another Comparator method :)
+    and not(parent::ArgumentList/parent::MethodCall[
+        pmd-java:typeIs('java.util.Comparator')
+    ])
+    (: used in non-static-final way :)
+    and not(ancestor::ClassBody[1]/FieldDeclaration[pmd-java:modifiers() = ('final','static')])
+]
+            ]]></value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class BadPerson implements Comparable<Person> {
+    @Override
+    public int compareTo(@NotNull Person o) {
+        return Comparator.comparing(Person::getFirstName)  // Bad: Creates new Comparator instance on each invocation
+                .thenComparing(Person::getLastName)
+                .thenComparingInt(Person::getAge)
+                .compare(this, o);
+    }
+}
 
+public class GoodPerson implements Comparable<Person> {
+    private static final Comparator<Person> COMPARE_AGE_LAST_FIRST =
+        Comparator.comparing(Person::getFirstName)
+            .thenComparing(Person::getLastName)
+            .thenComparingInt(Person::getAge);
+
+    @Override
+    public int compareTo(@NotNull Person o) {
+        return COMPARE_AGE_LAST_FIRST.compare(this, o);     // Good: Comparator initialized once as static final field
+    }
+}
+        ]]>
+        </example>
+    </rule>
 </ruleset>

--- a/src/test/java/com/jpinpoint/perf/lang/java/ruleset/common/InitializeComparatorOnlyOnceTest.java
+++ b/src/test/java/com/jpinpoint/perf/lang/java/ruleset/common/InitializeComparatorOnlyOnceTest.java
@@ -1,0 +1,6 @@
+package com.jpinpoint.perf.lang.java.ruleset.common;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class InitializeComparatorOnlyOnceTest extends PmdRuleTst {
+}

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
@@ -91,6 +91,36 @@ public class GoodPerson implements Comparable<GoodPerson> {
     </test-code>
 
     <test-code>
+        <description>Violation: reversed creates new Comparator object</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>16</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Comparator;
+
+public class ReversedPerson implements Comparable<ReversedPerson> {
+
+    private static final Comparator<ReversedPerson> COMPARATOR =
+            Comparator.comparing(GoodPerson::getFirstName)
+                    .thenComparing(GoodPerson::getLastName)
+                    .thenComparingInt(GoodPerson::getAge);
+
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    @Override
+    public int compareTo(ReversedPerson o) {
+        return COMPARATOR.reversed().compare(this, o); // bad, reversed creates new Comparator object
+    }
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>No violation: Static final Comparator in sorting class</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
@@ -100,9 +100,9 @@ import java.util.Comparator;
 public class ReversedPerson implements Comparable<ReversedPerson> {
 
     private static final Comparator<ReversedPerson> COMPARATOR =
-            Comparator.comparing(GoodPerson::getFirstName)
-                    .thenComparing(GoodPerson::getLastName)
-                    .thenComparingInt(GoodPerson::getAge);
+            Comparator.comparing(ReversedPerson::getFirstName)
+                    .thenComparing(ReversedPerson::getLastName)
+                    .thenComparingInt(ReversedPerson::getAge);
 
     private String firstName;
     private String lastName;
@@ -113,6 +113,34 @@ public class ReversedPerson implements Comparable<ReversedPerson> {
         return COMPARATOR.reversed().compare(this, o); // bad, reversed creates new Comparator object
     }
 
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Violation: compare with multiple params</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>10</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Comparator;
+
+public class BadPerson implements Comparable<BadPerson> {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    @Override
+    public int compareTo(BadPerson o) {
+        return Comparator.comparing(BadPerson::getFirstName, String.CASE_INSENSITIVE_ORDER) // bad, can be reused in static final
+                .thenComparing(BadPerson::getLastName)
+                .thenComparingInt(BadPerson::getAge)
+                .compare(this, o);
+    }
+
+    // getters omitted for brevity
     public String getFirstName() { return firstName; }
     public String getLastName() { return lastName; }
     public int getAge() { return age; }

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
@@ -188,6 +188,40 @@ public class MultipleComparators {
     </test-code>
 
     <test-code>
+        <description>No violation: Multiple static final comparators, one fixed</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>24</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+class Person {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+
+public class MultipleComparators {
+    private static final Comparator<Person> BY_AGE =
+            Comparator.comparingInt(Person::getAge);
+
+    public void sortByAge(List<Person> persons) {
+        Collections.sort(persons, BY_AGE);
+    }
+
+    public void sortByAge2(List<Person> persons) {
+        Collections.sort(persons, Comparator.comparingInt(Person::getAge)); // bad, can also use BY_AGE
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>No violation: Non-comparator methods</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/InitializeComparatorOnlyOnce.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Violation: Comparator created in compareTo method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>10</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Comparator;
+
+public class BadPerson implements Comparable<BadPerson> {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    @Override
+    public int compareTo(BadPerson o) {
+        return Comparator.comparing(BadPerson::getFirstName) // bad, can be reused in static final
+                .thenComparing(BadPerson::getLastName)
+                .thenComparingInt(BadPerson::getAge)
+                .compare(this, o);
+    }
+
+    // getters omitted for brevity
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Violation: Comparator created in sort method</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+class Person {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+
+public class BadSorting {
+    public static void sortPeople(List<Person> persons) {
+        Collections.sort(persons,
+                Comparator.comparingInt(Person::getAge) // bad, can be reused in static final
+                        .thenComparing(Person::getLastName)
+                        .thenComparing(Person::getFirstName));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No violation: Static final Comparator in comparable class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Comparator;
+
+public class GoodPerson implements Comparable<GoodPerson> {
+
+    private static final Comparator<GoodPerson> COMPARATOR =
+            Comparator.comparing(GoodPerson::getFirstName)
+                    .thenComparing(GoodPerson::getLastName)
+                    .thenComparingInt(GoodPerson::getAge);
+
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    @Override
+    public int compareTo(GoodPerson o) {
+        return COMPARATOR.compare(this, o);
+    }
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No violation: Static final Comparator in sorting class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+class Person {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+
+public class GoodSorting {
+    private static final Comparator<Person> PERSON_COMPARATOR =
+            Comparator.comparingInt(Person::getAge)
+                    .thenComparing(Person::getLastName)
+                    .thenComparing(Person::getFirstName);
+
+    public void sortPeople(List<Person> persons) {
+        Collections.sort(persons, PERSON_COMPARATOR);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Violation: using nullsFirst - expect one match only</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>18</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+class Person {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+
+public class NullComparator {
+    public void sortWithNulls(List<Person> persons) {
+        Comparator<Person> comparator =
+                Comparator.nullsFirst(Comparator.comparing(Person::getFirstName)); // bad, can be reused in static final
+        Collections.sort(persons, comparator);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No violation: Multiple static final comparators</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+class Person {
+    private String firstName;
+    private String lastName;
+    private int age;
+
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
+    public int getAge() { return age; }
+}
+
+public class MultipleComparators {
+    private static final Comparator<Person> BY_AGE =
+            Comparator.comparingInt(Person::getAge);
+
+    private static final Comparator<Person> BY_NAME =
+            Comparator.comparing(Person::getFirstName)
+                    .thenComparing(Person::getLastName);
+
+    public void sortByAge(List<Person> persons) {
+        Collections.sort(persons, BY_AGE);
+    }
+
+    public void sortByName(List<Person> persons) {
+        Collections.sort(persons, BY_NAME);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No violation: Non-comparator methods</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class NonComparatorClass {
+
+    public int compare(String a, String b) {
+        return this.comparing(Integer.valueOf(a), Integer.valueOf(b));
+    }
+
+    public int comparing(int a, int b) {
+        return Integer.compare(a, b);
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
Not sure if there can be exceptions to the rule, where the Comparator used "state" that is not thread safe or can be reused.