### PR TITLE
fix for #373: fix xpath and added dropped support warnings for portlets in Spring

### DIFF
--- a/docs/JavaCodePerformance.md
+++ b/docs/JavaCodePerformance.md
@@ -1458,6 +1458,9 @@ Note that for StringBuilder.substring this is not needed, since it does make a c
 
 #### TMSU11
 
+**Warning:** this is portlet specific, support has been dropped in Spring framework 5 and later. Alternative portlet support
+can be found here: [PortletMVC4Spring](https://github.com/liferay/portletmvc4spring)
+
 **Observation: ModelMaps are implicitly added to the session.** Spring BindingAwareModelMaps are implicitly and automagically added to the portlet session by Spring MVC under certain conditions. A Controller with the following code is problematic:
 
 ```java
@@ -1478,6 +1481,9 @@ Spring will inject the proper data types. The problem is that with portlets, a b
 Render parameters might be an option, see [TMSU01](#TMSU01).
 
 #### TMSU12
+
+**Warning:** this is portlet specific, support has been dropped in Spring framework 5 and later. Alternative portlet support
+can be found here: [PortletMVC4Spring](https://github.com/liferay/portletmvc4spring)
 
 **Observation: Form validation in an action request with ModelMaps or ModelAttributes is convenient, but they stay in the session after validation.**  
 **Problem:** ModelMaps are rather large objects and still take heap space while they are not needed anymore.  

--- a/rulesets/java/jpinpoint-java-rules.xml
+++ b/rulesets/java/jpinpoint-java-rules.xml
@@ -6565,17 +6565,20 @@ class Good {
                 <value><![CDATA[
 //MethodDeclaration[
     pmd-java:modifiers() = 'public'
+    and (pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.ActionMapping')
+        or pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping'))
+    and
+       (  .//FormalParameter[
+                    pmd-java:typeIs('org.springframework.ui.ModelMap')
+                    or pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')
+                  ]
+          or
 
-    and .//FormalParameter[
-            pmd-java:typeIs('org.springframework.ui.ModelMap')
-            or
-            pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')]
-
-    and .//FormalParameter[
-            (pmd-java:typeIs('javax.portlet.RenderRequest') or pmd-java:typeIs('javax.portlet.PortletRequest'))
-            or
-            pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping')
-        ]
+          .//FormalParameter[
+                    pmd-java:typeIs('javax.portlet.RenderRequest')
+                    or pmd-java:typeIs('javax.portlet.PortletRequest')
+                  ]
+        )
 ]
                 ]]></value>
             </property>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -6565,17 +6565,20 @@ class Good {
                 <value><![CDATA[
 //MethodDeclaration[
     pmd-java:modifiers() = 'public'
+    and (pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.ActionMapping')
+        or pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping'))
+    and
+       (  .//FormalParameter[
+                    pmd-java:typeIs('org.springframework.ui.ModelMap')
+                    or pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')
+                  ]
+          or
 
-    and .//FormalParameter[
-            pmd-java:typeIs('org.springframework.ui.ModelMap')
-            or
-            pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')]
-
-    and .//FormalParameter[
-            (pmd-java:typeIs('javax.portlet.RenderRequest') or pmd-java:typeIs('javax.portlet.PortletRequest'))
-            or
-            pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping')
-        ]
+          .//FormalParameter[
+                    pmd-java:typeIs('javax.portlet.RenderRequest')
+                    or pmd-java:typeIs('javax.portlet.PortletRequest')
+                  ]
+        )
 ]
                 ]]></value>
             </property>

--- a/src/main/resources/category/java/spring.xml
+++ b/src/main/resources/category/java/spring.xml
@@ -104,17 +104,20 @@ class Good {
                 <value><![CDATA[
 //MethodDeclaration[
     pmd-java:modifiers() = 'public'
+    and (pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.ActionMapping')
+        or pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping'))
+    and
+       (  .//FormalParameter[
+                    pmd-java:typeIs('org.springframework.ui.ModelMap')
+                    or pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')
+                  ]
+          or
 
-    and .//FormalParameter[
-            pmd-java:typeIs('org.springframework.ui.ModelMap')
-            or
-            pmd-java:hasAnnotation('org.springframework.web.bind.annotation.ModelAttribute')]
-
-    and .//FormalParameter[
-            (pmd-java:typeIs('javax.portlet.RenderRequest') or pmd-java:typeIs('javax.portlet.PortletRequest'))
-            or
-            pmd-java:hasAnnotation('org.springframework.web.portlet.bind.annotation.RenderMapping')
-        ]
+          .//FormalParameter[
+                    pmd-java:typeIs('javax.portlet.RenderRequest')
+                    or pmd-java:typeIs('javax.portlet.PortletRequest')
+                  ]
+        )
 ]
                 ]]></value>
             </property>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/spring/xml/AvoidModelMapAsRenderParameter.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/spring/xml/AvoidModelMapAsRenderParameter.xml
@@ -5,8 +5,8 @@
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
         <description>Avoid ModelMap as render parameter</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>20, 38, 47, 57</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>47, 57</expected-linenumbers>
         <code><![CDATA[
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.Validator;
@@ -26,7 +26,7 @@ public class AvoidModelMapAsRenderParameterTest {
 
 	// ModelMap in session between action and render, and after that
 	// render in method name, no RenderRequest param
-	@ResourceMapping("subview-init") // bad [--> NOT, see JPCC-88?]
+	@ResourceMapping("subview-init") // ok (was false positive)
 	public String initialOverviewRender0(final PortletRequest request,
 			final ModelMap modelMap, @RequestParam("viewName") final String viewName) {
 		modelMap.put("texts", messageSource);
@@ -44,7 +44,7 @@ public class AvoidModelMapAsRenderParameterTest {
 	}
 
 	// ModelMap in session between action and render, and after that
-	@ResourceMapping("subview-init") // bad [--> NOT, see JPCC-88?]
+	@ResourceMapping("subview-init") // ok (was false positive)
 	public String initialOverviewRender1(final RenderRequest request,
 			final ModelMap modelMap, @RequestParam("viewName") final String viewName) {
 		modelMap.put("texts", messageSource);
@@ -53,7 +53,7 @@ public class AvoidModelMapAsRenderParameterTest {
 	}
 
 	// ModelMap in session between action and render, and after that
-    @RenderMapping(params = "flow=view_unsigned") // bad
+    @RenderMapping(params = "flow=view_unsigned") // bad 47
     public ModelAndView viewUnsignedDoodle(final RenderRequest request, @RequestParam final String doodleId,
                                             @RequestParam final String modifiedTimeStamp, ModelMap modelMap,
                                             final Object flow)
@@ -63,7 +63,7 @@ public class AvoidModelMapAsRenderParameterTest {
     }
 
     // @ModelAttribute creates an implicit ModelMap in session
-    @RenderMapping(params = "RENDER=SECOND_SCREEN_FIRST_TIME") // bad
+    @RenderMapping(params = "RENDER=SECOND_SCREEN_FIRST_TIME") // bad 57
     public ModelAndView renderSecondScreenFirstTime(final RenderRequest request,
                                                     final @ModelAttribute Object firstScreenForm)
     {
@@ -82,6 +82,30 @@ public class AvoidModelMapAsRenderParameterTest {
 	   return new ModelAndView("income/" + viewName, modelMap);
     }
 
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Avoid ModelMap as render parameter - part 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>14</expected-linenumbers>
+        <code><![CDATA[
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.bind.annotation.ActionMapping;
+import org.springframework.web.portlet.bind.annotation.RenderMapping;
+
+@Controller
+@RequestMapping("VIEW")
+public class FooView {
+
+    @ActionMapping("foo")
+    public void foo(final ActionRequest request, final ModelMap modelMap) {
+        modelMap.put("id", String.valueOf(System.currentTimeMillis()));
+    }
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
closes #373 

created "band-aid" solution, should we keep this rule for dropped portlet support?