### PR TITLE
fix #607: Kotlin: also have AvoidDecimalAndChoiceFormatAsField work in object instead of class

### DIFF
--- a/src/main/resources/category/kotlin/common.xml
+++ b/src/main/resources/category/kotlin/common.xml
@@ -94,7 +94,7 @@ class AvoidStringBuffer {
 //ImportHeader[.//T-Identifier[@Text='java'] and .//T-Identifier[@Text='text']][1]/ancestor::KotlinFile
 (: PrimaryExpression finds the constructors instead of type declarations :)
 (: filter matches in functions :)
-//ClassDeclaration//PrimaryExpression//SimpleIdentifier//T-Identifier[
+//TopLevelObject//PrimaryExpression//SimpleIdentifier//T-Identifier[
  (@Text="DecimalFormat" or @Text="ChoiceFormat")
  and not(ancestor::FunctionBody)
 ]

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidDecimalAndChoiceFormatAsField.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidDecimalAndChoiceFormatAsField.xml
@@ -31,4 +31,34 @@ class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description>violation: Avoid DecimalFormat and ChoiceFormat as field in object</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,10,17,22</expected-linenumbers>
+        <code><![CDATA[
+import java.text.ChoiceFormat
+import java.text.DecimalFormat
+import java.text.NumberFormat
+
+object Foo {
+    private val numFormat: NumberFormat = DecimalFormat("###.###") //bad
+
+    private val limits = doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+    private val dayOfWeekNames = arrayOf("Sun", "Mon", "Tue", "Wed", "Thur", "Fri", "Sat")
+    private val form = ChoiceFormat(limits, dayOfWeekNames) // bad
+
+    fun shouldNotMatchInsideMethod() {
+        val format: NumberFormat = DecimalFormat("##.##")
+        val choiceFormat = ChoiceFormat(limits, dayOfWeekNames)
+    }
+    object Test {
+        val format: NumberFormat = DecimalFormat("##.##") // bad
+    }
+}
+
+object Foo2 {
+    private val numFormat: NumberFormat = DecimalFormat("###.###") //bad
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Not sure what fix is better:

`//(ClassDeclaration|ObjectDeclaration)`

or 

`//TopLevelObject` (this is now in the rule)