### PR TITLE
Fix Request for AvoidExcessiveClassloadingWithSaajSoap: Documentation: Axiom support returned to Spring Web Services 4.1 #606 

### DIFF
--- a/docs/JavaCodePerformance.md
+++ b/docs/JavaCodePerformance.md
@@ -522,7 +522,8 @@ class AvoidHardcodedConnectionConfig {
 2. If you want or have to use SAAJ, set the proper JVM parameter/system property for TransformerFactory and MessageFactory (see IUOXAR09 link below) to prevent the excessive class loading.    
 **Note:** When you have solved this isssue with JVM params or like the example, yet, in another file then where the violation occurs, just suppress the rule with the reason explained, how it is solved.    
 
-**Note:** Unfortunately, [AxiomSoapMessageFactory has been removed from spring-ws with Spring Boot 3.0](https://spring.io/blog/2022/12/02/spring-ws-samples-upgraded-for-spring-boot-3-0). In that case, only solution 2 seems feasible.   
+**Note 1:** Unfortunately, [AxiomSoapMessageFactory has been removed from spring-ws with Spring Boot 3.0](https://spring.io/blog/2022/12/02/spring-ws-samples-upgraded-for-spring-boot-3-0). In that case, only solution 2 seems feasible.   
+**Note 2:** Fortunately, [It has been re-introduced in spring-ws with Spring Boot 4.1](https://github.com/spring-projects/spring-ws/issues/1454)!    
 **Rule name:** AvoidExcessiveClassloadingWithSaajSoap   
 **Example:**
 ```java
@@ -584,7 +585,7 @@ public class Foo {
 #### IBI25
 **Observation: ClientHttpRequestInterceptor is not releasing the connection when it throws an Exception.**   
 **Problem:** If the interceptor throws an exception after receiving a response, resources are not released as happens with normal program flow.
-It causes the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.   
+For instance, it may cause the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.   
 **Solution:** Release resources by closing the response via ClientHttpResponse.close() when throwing an Exception.   
 **Rule name:** HttpInterceptorNotReleasingOnException   
 **Example:**

--- a/rulesets/java/jpinpoint-java-rules.xml
+++ b/rulesets/java/jpinpoint-java-rules.xml
@@ -5109,11 +5109,12 @@ class Good {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           language="java"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#ibi23">
-        <description>Problem: SAAJ uses DOM to load the XML document in memory which uses a TransformerFactory. The
-            implementation class of it is loaded on every call which causes lock contention under load. This means long
+        <description>Problem: SAAJ uses DOM to load the XML document in memory, which uses a TransformerFactory. The
+            implementation class of it is loaded on every call that causes lock contention under load. This means long
             response times.&#13;
             Solution: If possible, use Axiom SOAP messaging which uses the faster StAX. If you have/want to stick to
             SAAJ, set the proper system properties to prevent the excessive class loading.
+            Note: Axiom (2.0) is available again in Spring web services, since version 4.1.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>
@@ -6096,7 +6097,7 @@ public class HttpClientStuff {
           language="java"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#ibi25">
         <description>Problem: If the interceptor throws an exception after receiving a response, resources are not released as happens with normal program flow.
-            It causes the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
+            For instance, it may cause the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
             Solution: Release resources by closing the response via ClientHttpResponse.close() when throwing an Exception.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -5109,11 +5109,12 @@ class Good {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           language="java"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#ibi23">
-        <description>Problem: SAAJ uses DOM to load the XML document in memory which uses a TransformerFactory. The
-            implementation class of it is loaded on every call which causes lock contention under load. This means long
+        <description>Problem: SAAJ uses DOM to load the XML document in memory, which uses a TransformerFactory. The
+            implementation class of it is loaded on every call that causes lock contention under load. This means long
             response times.&#13;
             Solution: If possible, use Axiom SOAP messaging which uses the faster StAX. If you have/want to stick to
             SAAJ, set the proper system properties to prevent the excessive class loading.
+            Note: Axiom (2.0) is available again in Spring web services, since version 4.1.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>
@@ -6096,7 +6097,7 @@ public class HttpClientStuff {
           language="java"
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#ibi25">
         <description>Problem: If the interceptor throws an exception after receiving a response, resources are not released as happens with normal program flow.
-            It causes the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
+            For instance, it may cause the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
             Solution: Release resources by closing the response via ClientHttpResponse.close() when throwing an Exception.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>

--- a/src/main/resources/category/java/remoting.xml
+++ b/src/main/resources/category/java/remoting.xml
@@ -1297,11 +1297,12 @@ class AvoidHardcodedConnectionConfig {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           language="java"
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#ibi23">
-        <description>Problem: SAAJ uses DOM to load the XML document in memory which uses a TransformerFactory. The
-            implementation class of it is loaded on every call which causes lock contention under load. This means long
+        <description>Problem: SAAJ uses DOM to load the XML document in memory, which uses a TransformerFactory. The
+            implementation class of it is loaded on every call that causes lock contention under load. This means long
             response times.&#13;
             Solution: If possible, use Axiom SOAP messaging which uses the faster StAX. If you have/want to stick to
             SAAJ, set the proper system properties to prevent the excessive class loading.
+            Note: Axiom (2.0) is available again in Spring web services, since version 4.1.
             (jpinpoint-rules)
         </description>
         <priority>2</priority>
@@ -1386,7 +1387,7 @@ public class Foo {
           language="java"
           externalInfoUrl="${doc_root}/JavaCodePerformance.md#ibi25">
         <description>Problem: If the interceptor throws an exception after receiving a response, resources are not released as happens with normal program flow.
-            It causes the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
+            For instance, it may cause the connection not to be released to the connection pool, which leads to pool exhaustion and unresponsiveness.
             Solution: Release resources by closing the response via ClientHttpResponse.close() when throwing an Exception.
             (jpinpoint-rules)
         </description>


### PR DESCRIPTION
Documentation: Axiom support returned to Spring Web Services 4.1 #606 
Also make doc of HttpInterceptorNotReleasingOnException more conform the api javadoc.