### PR TITLE
fix #618: skip Set<Class> in formal parameters as cannot tell instantatiation of Set

### DIFF
--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -1971,10 +1971,10 @@ public enum Fruit {
 (: declared variable used in Set by-element access :)
 //VariableId[@Name = ancestor::ClassBody//MethodCall[@MethodName = ('contains','containsAll','remove','removeAll','retainAll')]/VariableAccess/@Name]
     (: for 3 ways defined as a Set :)
-    [(ancestor::FieldDeclaration|ancestor::LocalVariableDeclaration|ancestor::FormalParameter)/ClassType[pmd-java:typeIs('java.util.Set')
-                                                                                                         (: not when Set constructed with Comparator :)
-                                                                                                          and not(..//ConstructorCall[pmd-java:matchesSig('java.util.TreeSet#new(java.util.Comparator)')])
-                                                                                                         ]
+    [(ancestor::FieldDeclaration|ancestor::LocalVariableDeclaration)/ClassType[pmd-java:typeIs('java.util.Set')
+                                                                                (: not when Set constructed with Comparator :)
+                                                                                 and not(..//ConstructorCall[pmd-java:matchesSig('java.util.TreeSet#new(java.util.Comparator)')])
+                                                                              ]
     (: element type does not implement Comparable :)
      /TypeArguments/ClassType[not(pmd-java:typeIs('java.lang.Comparable'))
     (: and can be resolved :)
@@ -1985,32 +1985,39 @@ public enum Fruit {
         </properties>
         <example>
             <![CDATA[
-import java.util.*;
 import org.apache.hc.client5.http.HttpRoute; // does implement equals/hashCode yet *not* compareTo
+import java.util.*;
 
 class Foo {
-  Set<String> strSet = new HashSet<>();
-  List<String> strList = new ArrayList<>();
-  Set<HttpRoute> fieldRouteSet = new HashSet<>(); // bad
-  List<HttpRoute> routeList = new ArrayList<>();
 
-  void byElemBad(Set<HttpRoute> paramRouteSet) { // bad
-    paramRouteSet.retainAll(routeList);
+    public static final Comparator<HttpRoute> HTTP_ROUTE_COMPARATOR =
+            Comparator.comparing((HttpRoute route) -> route.getTargetHost().getHostName())
+                    .thenComparingInt(route -> route.getTargetHost().getPort());
 
-    fieldRouteSet.contains(t);
+    Set<String> strSet = new HashSet<>();
+    List<String> strList = new ArrayList<>();
+    Set<HttpRoute> fieldRouteSet = new HashSet<>(); // bad
+    Set<HttpRoute> fieldRouteSetComp = new TreeSet<>(HTTP_ROUTE_COMPARATOR); // good: with explicit comparator
+    List<HttpRoute> routeList = new ArrayList<>();
 
-    Set<HttpRoute> localRouteSet = new HashSet<>(); // bad
-    localRouteSet.removeAll(routeList);
-  }
+    void byElemBad(Set<HttpRoute> paramRouteSet) { // probably bad, but cannot tell the actual constructor of the Set
+        paramRouteSet.retainAll(routeList);
 
-  void otherCasesGood(Set<HttpRoute> paramRouteSet) {
-    strSet.contains("bla");
-    strSet.retainAll(strList);
-    strSet.remove("other");
-    paramRouteSet.iterator().next();
-  }
+        HttpRoute firstRoute = paramRouteSet.iterator().next();
+        fieldRouteSet.contains(firstRoute);
+
+        Set<HttpRoute> localRouteSet = new HashSet<>(); // bad
+        localRouteSet.removeAll(routeList);
+    }
+
+    void otherCasesGood(Set<HttpRoute> paramRouteSet) { // probably bad, but cannot tell the actual constructor of the Set
+        strSet.contains("bla");
+        strSet.retainAll(strList);
+        strSet.remove("other");
+        paramRouteSet.iterator().next();
+    }
 }
-            ]]>
+]]>
         </example>
     </rule>
 

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/NonComparableSetElements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/NonComparableSetElements.xml
@@ -5,23 +5,23 @@
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
         <description>violation: NonComparableSetElements</description>
-        <expected-problems>6</expected-problems>
-        <expected-linenumbers>6, 13, 14, 21, 24, 28</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6, 14, 21, 24</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 import org.apache.hc.client5.http.HttpRoute; // does implement equals/hashCode yet not compareTo
 // Thread does not implement equals/hashCode nor compareTo
 class Foo {
     Set<String> strSet = new HashSet<>();
-    Set<Thread> threadFieldSet = new HashSet<>(); // bad
+    Set<Thread> threadFieldSet = new HashSet<>(); // bad 6
     Thread t = new Thread();
     List<String> strList = new ArrayList<>();
     List<Thread> tList = new ArrayList<>();
     Set<HttpRoute> routeSet = new HashSet<>();
     Set tSet = new HashSet();
 
-    void byElemBad(Set<Thread> threadParamSet) { // bad 13
-        Set<Thread> localThreadFieldSet = new HashSet<>(); // bad
+    void byElemBad(Set<Thread> threadParamSet) { // probably bad, but cannot tell actual Set implementation and construction
+        Set<Thread> localThreadFieldSet = new HashSet<>(); // bad 14
 
         threadParamSet.retainAll(tList);
         localThreadFieldSet.containsAll(tList);
@@ -31,11 +31,11 @@ class Foo {
         Set<Thread> threadLocalSet = new HashSet<>(); // bad 21
         threadLocalSet.containsAll(tList);
 
-        Set<HttpRoute> routeLocalSet = new HashSet<>(); // bad
+        Set<HttpRoute> routeLocalSet = new HashSet<>(); // bad 24
         routeLocalSet.removeAll(routeSet);
     }
 
-    void otherCasesGood(Set<Thread> threadParamSet2) { // bad 28
+    void otherCasesGood(Set<Thread> threadParamSet2) { // probably bad, but cannot tell actual Set implementation and construction
         strSet.contains("bla");
         strSet.containsAll(strList);
         strSet.retainAll(strList);
@@ -54,6 +54,7 @@ class Foo {
         <expected-problems>0</expected-problems>
 
         <code><![CDATA[
+import java.util.Comparator;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -79,6 +80,32 @@ public class Issue568 {
         boolean containsAllOf(Set otherSet) {
             return someSet.containsAll(otherSet);
         }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>false positive: NonComparableSetKeys Issue #618</description>
+        <expected-problems>0</expected-problems>
+
+        <code><![CDATA[
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class Foo {
+
+    public static final Comparator<Class> CLASS_NAME_COMPARATOR = Comparator.comparing(Class::getName);
+
+    public void bar() {
+        final Set<Class> types = new TreeSet<>(CLASS_NAME_COMPARATOR);
+        foo(types);
+    }
+
+    public void foo(Set<Class> types) { // <--- false positive, has constructor with comparator
+        types.contains(String.class);
+    }
+
 }
      ]]></code>
     </test-code>


### PR DESCRIPTION
To prevent false positives the matches on FormalParams has been removed: you cannot tell the Set implementation and initiation (expect in same class, but that is already checked by the rule).

Question: should we add to documentation to use SuppressWarning annotation when it is known the set is only for small numbers and the risk of having more than 7 elements in a _bucket_ is minimal?