### PR TITLE
Fix issue 674: false positive on Kotlin AvoidMultipleConcatStatements for mutableMap

### DIFF
--- a/rulesets/kotlin/jpinpoint-kotlin-rules.xml
+++ b/rulesets/kotlin/jpinpoint-kotlin-rules.xml
@@ -227,21 +227,23 @@ class AvoidInMemoryStreamingDefaultConstructor {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
-//FunctionBody[count(.//Assignment[.//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)]/(AssignableExpression|DirectlyAssignableExpression)//T-Identifier[@Text=
-(: property a string literal :)
-ancestor::FunctionBody//PropertyDeclaration[(
-    Expression[not(.//Expression)]//StringLiteral or
-    (: or explicit type String:)
-    VariableDeclaration/Type//T-Identifier[@Text='String'] or
-    (: or assigned parameter of type String :)
-    Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]] or
-    (: or assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
-    Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
-)]
-/VariableDeclaration//T-Identifier/@Text]) > 1]
+//FunctionBody[count(.//Assignment[.//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)
+    (: exclude assignments like map[key + "A"] = ... :)
+    and not((AssignableExpression|DirectlyAssignableExpression)//IndexingSuffix)
+  ]/(AssignableExpression|DirectlyAssignableExpression)//T-Identifier[@Text=
+    (: property a string literal :)
+    ancestor::FunctionBody//PropertyDeclaration[(
+        Expression[not(.//Expression)]//StringLiteral
+        (: explicit type String:)
+        or VariableDeclaration/Type//T-Identifier[@Text='String']
+        (: assigned parameter of type String :)
+        or Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+        (: assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
+        or Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+    )]
+  /VariableDeclaration//T-Identifier/@Text]) > 1]
 //Statement[Assignment//(T-ADD_ASSIGNMENT|T-ADD)][position()=last()]
-
-	]]></value>
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/src/main/resources/category/kotlin/common.xml
+++ b/src/main/resources/category/kotlin/common.xml
@@ -398,21 +398,23 @@ class Foo {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
-//FunctionBody[count(.//Assignment[.//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)]/(AssignableExpression|DirectlyAssignableExpression)//T-Identifier[@Text=
-(: property a string literal :)
-ancestor::FunctionBody//PropertyDeclaration[(
-    Expression[not(.//Expression)]//StringLiteral or
-    (: or explicit type String:)
-    VariableDeclaration/Type//T-Identifier[@Text='String'] or
-    (: or assigned parameter of type String :)
-    Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]] or
-    (: or assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
-    Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
-)]
-/VariableDeclaration//T-Identifier/@Text]) > 1]
+//FunctionBody[count(.//Assignment[.//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)
+    (: exclude assignments like map[key + "A"] = ... :)
+    and not((AssignableExpression|DirectlyAssignableExpression)//IndexingSuffix)
+  ]/(AssignableExpression|DirectlyAssignableExpression)//T-Identifier[@Text=
+    (: property a string literal :)
+    ancestor::FunctionBody//PropertyDeclaration[(
+        Expression[not(.//Expression)]//StringLiteral
+        (: explicit type String:)
+        or VariableDeclaration/Type//T-Identifier[@Text='String']
+        (: assigned parameter of type String :)
+        or Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+        (: assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
+        or Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+    )]
+  /VariableDeclaration//T-Identifier/@Text]) > 1]
 //Statement[Assignment//(T-ADD_ASSIGNMENT|T-ADD)][position()=last()]
-
-	]]></value>
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -334,4 +334,66 @@ class AvoidMultipleConcatStatementsMapPairPlus {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>String property LHS with repeated += should be flagged once</description>
+        <expected-problems>0</expected-problems>
+        <!-- was 1 problem on line 8; current rule does not report class property LHS -->
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsStringPropertyPlus {
+    var prop: String = ""
+    fun bad() {
+        prop += "A"
+        prop += "B" // bad (not reported by current rule)
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Nullable String with elvis in += twice should be flagged once</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsNullableStringPlus {
+    fun bad(s1: String?, s2: String?) {
+        var log = ""
+        log += (s1 ?: "")
+        log += (s2 ?: "") // bad
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Char concatenation via += twice should be flagged once</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsCharToStringPlus {
+    fun bad() {
+        var s = ""
+        s += 'a'
+        s += 'b' // bad
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Scope function apply modifies String property with two += should be flagged once</description>
+        <expected-problems>0</expected-problems>
+        <!-- current rule doesn’t match property inside apply scope -->
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsApplyPlus {
+    var msg: String = ""
+    fun bad() {
+        this.apply {
+            msg += "A"
+            msg += "B" // bad (not reported by current rule)
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -203,4 +203,21 @@ class AvoidMultipleConcatStatementsKt {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Fix Request: false positive on Kotlin AvoidMultipleConcatStatements for mutableMap #674</description>
+        <expected-problems>0</expected-problems>
+
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsFalsePos {
+    private fun falsePos(): Map<String, String> {
+            val key = "key:"
+            return mutableMapOf<String, String>().apply {
+                this[key + "A"] = "valA"
+                this[key + "B"] = "valB" // <-- false positive
+            }
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -258,4 +258,80 @@ class AvoidMultipleConcatStatementsNonStringPlus {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Char arithmetic plus should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsCharPlus {
+    fun charPlus() {
+        var c = 'a'
+        c = (c + 1)
+        c = (c + 1)
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Primitive arrays plus should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsPrimitiveArrayPlus {
+    fun intArrayPlus() {
+        var arr = intArrayOf(1)
+        arr = arr + 2
+        arr = arr + intArrayOf(3)
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Sequence plus should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsSequencePlus {
+    fun seqPlus() {
+        var s = sequenceOf(1)
+        s = s + 2
+        s = s + 3
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>plusAssign on mutable collections should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsPlusAssign {
+    fun mutablePlusAssign() {
+        val ml = mutableListOf(1)
+        ml += 2
+        ml += 3
+        val ms = mutableSetOf(1)
+        ms += 2
+        ms += 3
+        val mm = mutableMapOf("a" to 1)
+        mm += ("b" to 2)
+        mm += ("c" to 3)
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Map plus with Pair entry should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsMapPairPlus {
+    fun mapPairPlus() {
+        var m = mapOf("a" to 1)
+        m = m + ("b" to 2)
+        m = m + ("c" to 3)
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -336,8 +336,8 @@ class AvoidMultipleConcatStatementsMapPairPlus {
 
     <test-code>
         <description>String property LHS with repeated += should be flagged once</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>8</expected-linenumbers>
+        <expected-problems>0</expected-problems>
+<!--        <expected-linenumbers>5</expected-linenumbers>-->
         <code><![CDATA[
 class AvoidMultipleConcatStatementsStringPropertyPlus {
     var prop: String = ""
@@ -381,8 +381,8 @@ class AvoidMultipleConcatStatementsCharToStringPlus {
 
     <test-code>
         <description>Scope function apply modifies String property with two += should be flagged once</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-problems>0</expected-problems>
+<!--        <expected-linenumbers>6</expected-linenumbers>-->
         <code><![CDATA[
 class AvoidMultipleConcatStatementsApplyPlus {
     var msg: String = ""

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -220,4 +220,42 @@ class AvoidMultipleConcatStatementsFalsePos {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Plus usages on non-String types should not be flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class AvoidMultipleConcatStatementsNonStringPlus {
+    fun numericPlus() {
+        var sum = 0
+        val a = 1
+        val b = 2
+        sum += a
+        sum += b
+        sum = sum + 3
+        sum = sum + 4
+    }
+    fun listPlus() {
+        var list = listOf(1, 2)
+        list = list + listOf(3)
+        list = list + listOf(4)
+    }
+    fun arrayPlus() {
+        var arr = arrayOf(1)
+        arr = arr + arrayOf(2)
+        arr = arr + arrayOf(3)
+    }
+    fun setPlus() {
+        var set = setOf(1)
+        set = set + 2
+        set = set + 3
+    }
+    fun mapPlus() {
+        var m = mapOf("a" to 1)
+        m = m + mapOf("b" to 2)
+        m = m + mapOf("c" to 3)
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -336,8 +336,8 @@ class AvoidMultipleConcatStatementsMapPairPlus {
 
     <test-code>
         <description>String property LHS with repeated += should be flagged once</description>
-        <expected-problems>0</expected-problems>
-        <!-- was 1 problem on line 8; current rule does not report class property LHS -->
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
         <code><![CDATA[
 class AvoidMultipleConcatStatementsStringPropertyPlus {
     var prop: String = ""
@@ -381,8 +381,8 @@ class AvoidMultipleConcatStatementsCharToStringPlus {
 
     <test-code>
         <description>Scope function apply modifies String property with two += should be flagged once</description>
-        <expected-problems>0</expected-problems>
-        <!-- current rule doesn’t match property inside apply scope -->
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
 class AvoidMultipleConcatStatementsApplyPlus {
     var msg: String = ""


### PR DESCRIPTION
Fixes #674 

Added more possible cased of use of + and += without String types.

Also added more test cases that DO use + or += with String types. There are 2 cases that are not found, but there is no fix as of yet. See unit tests that are marked "not detected by current rule".