### PR TITLE
Fix issue 651 - additional changes AvoidMultipleConcatStatements

### DIFF
--- a/rulesets/kotlin/jpinpoint-kotlin-rules.xml
+++ b/rulesets/kotlin/jpinpoint-kotlin-rules.xml
@@ -228,6 +228,8 @@ class AvoidInMemoryStreamingDefaultConstructor {
             <property name="xpath">
                 <value><![CDATA[
 //FunctionBody[
+  not(ancestor::FunctionDeclaration/SimpleIdentifier/T-Identifier[@Text='hashCode'])
+  and
   count(
     .//Assignment[
       .//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)
@@ -257,6 +259,7 @@ class AvoidInMemoryStreamingDefaultConstructor {
         <example>
 
         </example>
+
     </rule>
 
     <rule name="AvoidRecompilingPatterns"

--- a/rulesets/kotlin/jpinpoint-kotlin-rules.xml
+++ b/rulesets/kotlin/jpinpoint-kotlin-rules.xml
@@ -227,21 +227,31 @@ class AvoidInMemoryStreamingDefaultConstructor {
             <property name="tag" value="jpinpoint-rule" type="String" description="for-sonar"/>
             <property name="xpath">
                 <value><![CDATA[
-//FunctionBody[count(.//Assignment[.//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)]/(AssignableExpression|DirectlyAssignableExpression)//T-Identifier[@Text=
-(: property a string literal :)
-ancestor::FunctionBody//PropertyDeclaration[(
-    Expression[not(.//Expression)]//StringLiteral or
-    (: or explicit type String:)
-    VariableDeclaration/Type//T-Identifier[@Text='String'] or
-    (: or assigned parameter of type String :)
-    Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]] or
-    (: or assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
-    Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
-)]
-/VariableDeclaration//T-Identifier/@Text]) > 1]
+//FunctionBody[
+  count(
+    .//Assignment[
+      .//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)
+      and
+      (AssignableExpression|DirectlyAssignableExpression)//T-Identifier[
+        (: property a string literal :)
+        @Text = ancestor::FunctionBody//PropertyDeclaration[
+          (
+            Expression[not(.//Expression)]//StringLiteral
+            (: explicit type String:)
+            or VariableDeclaration/Type//T-Identifier[@Text='String']
+            (: assigned parameter of type String :)
+            or Expression[.//T-Identifier[@Text = ancestor::FunctionDeclaration/FunctionValueParameters/FunctionValueParameter[Parameter/Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+            (: assigned non-nested function of explicit type String :) (: known issue: ignores parameters, may give false positives with overloaded methods :)
+            or Expression[.//T-Identifier[not(ancestor::CallSuffix)][@Text = ancestor::ClassMemberDeclarations//FunctionDeclaration[Type//T-Identifier[@Text='String']]//T-Identifier/@Text]]
+          )
+          and not(Expression//T-Identifier[@Text='toMutableList'])
+        ]/VariableDeclaration//T-Identifier/@Text
+      ]
+    ]
+  ) > 1
+]
 //Statement[Assignment//(T-ADD_ASSIGNMENT|T-ADD)][position()=last()]
-
-	]]></value>
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/src/main/resources/category/kotlin/common.xml
+++ b/src/main/resources/category/kotlin/common.xml
@@ -399,6 +399,8 @@ class Foo {
             <property name="xpath">
                 <value><![CDATA[
 //FunctionBody[
+  not(ancestor::FunctionDeclaration/SimpleIdentifier/T-Identifier[@Text='hashCode'])
+  and
   count(
     .//Assignment[
       .//(AssignmentAndOperator/T-ADD_ASSIGNMENT|AdditiveOperator/T-ADD)
@@ -428,6 +430,7 @@ class Foo {
         <example>
 
         </example>
+
     </rule>
 
     <rule name="AvoidWideScopeXPathExpression"

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -326,4 +326,25 @@ class HashCodeSample(
         ]]></code>
     </test-code>
 
+    <test-code>
+        <!-- this is a known ommission to avoid false positives on hashCode implementations -->
+        <!-- currently hard to implement in XPath, so keep this test around for a future fix -->
+        <description>INACTIVE CHECK: hashCode with explicit String concatenation should be flagged</description>
+        <expected-problems>0</expected-problems>
+<!--        <expected-linenumbers>8</expected-linenumbers>-->
+        <code><![CDATA[
+class HashCodeStringConcat(
+    private val a: String,
+    private val b: String
+) {
+    override fun hashCode(): Int {
+        var s = "" // String LHS
+        s += a
+        s += b // bad 8
+        return s.length // returns Int, but rule should still flag string concatenation
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -300,4 +300,31 @@ class NonStringPlusUsages {
     ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Kotlin hashCode numeric plus should not trigger AvoidMultipleConcatStatements</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class HashCodeSample(
+    group1: String,
+    group2: String,
+    group3: String
+) {
+    private val group1: String
+    private val group2: String
+    private val group3: String
+
+    // note: without this line, there is no false positive
+    override fun toString(): String = java.lang.String.join(group1, group2, group3)
+
+    override fun hashCode(): Int {
+        var result = group1.hashCode()
+        result = 31 * result + group2.hashCode()
+        result = 31 * result + group3.hashCode() // <-- false positive
+        return result
+    }
+}
+        ]]></code>
+    </test-code>
+
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/kotlin/ruleset/common/xml/AvoidMultipleConcatStatements.xml
@@ -326,5 +326,4 @@ class HashCodeSample(
         ]]></code>
     </test-code>
 
-
 </test-data>


### PR DESCRIPTION
* merge
* found hashCode false positive

* now exclude on hashCode fun, but that if obvious String concat is inside hashCode it is not found: added INACTIVE test for this, to be fixed when needed