### PR TITLE
pmd7-issue697 Extend AvoidLoadingAllFromFile with all major load‑all‑into‑memory patterns

### DIFF
--- a/docs/JavaCodePerformance.md
+++ b/docs/JavaCodePerformance.md
@@ -2080,6 +2080,10 @@ This especially applies to direct file streaming. Access through ClassLoader.get
 
 **Observation: All bytes of a large file are loaded into memory.** E.g. for uploading or downloading documents, for instance to determine the mime type or create a digest.    
 **Problem:** Large objects are allocated on the heap, up to e.g. 50 MB. We also observed 300 MB and even 1 GB in back-end systems. This likely triggers long gc pauses for compaction or may trigger out of memory crashes.
+APIs like `Files.readAllBytes`, `Files.readAllLines`, `Files.readString`, `InputStream.readAllBytes`, `IOUtils.toByteArray`, `ByteArrayInputStream`,
+`ByteArrayOutputStream.toByteArray`, and `ResizableByteArrayOutputStream.toByteArray` all load entire content into heap memory. 
+This risks OutOfMemoryError, long GC pauses, and slow responses when processing large files.   
+**Note:** Not a problem for small files.
 
 In the next example, there are two large byte arrays in memory: one in baos and the other is the returned byte array since a copy is made in toByteArray().
 
@@ -2102,7 +2106,8 @@ class Bad1 {
 }
 ```
 
-**Solution:** Stream-through: use streaming all the way, don't store the whole thing in memory, don't use byte arrays. A mime type is determined from the first few bytes of the file, don't read in all 50 MB - 1 GB for that. Often, functionality can be achieved in a streaming way, i.e. [a digest can be computed in a streaming way](http://www.mkyong.com/java/java-sha-hashing-example/).
+**Solution:** Use streaming APIs end-to-end, do not buffer whole files in memory.   
+A mime type is determined from the first few bytes of the file, don't read in all 50 MB - 1 GB for that. Usually, functionality can be achieved in a streaming way, i.e. [a digest can be computed in a streaming way](http://www.mkyong.com/java/java-sha-hashing-example/).
 
 Example 1 improved:
 

--- a/rulesets/java/jpinpoint-java-rules.xml
+++ b/rulesets/java/jpinpoint-java-rules.xml
@@ -481,49 +481,96 @@ class IterationsBetter {
     </rule>
 
     <rule name="AvoidLoadingAllFromFile"
-          language="java"
-          message="Files.readAll methods load all bytes from a file into memory: a risk of memory problems."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        language="java"
+        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
 
-          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
-        <description>Problem: Files.readAllBytes and Files.readAllLines load all bytes from a file into the heap memory.
-            This may result in an OutOfMemoryError crash, or long gc pauses and slow responses.
-            Solution: Stream-through: use streaming all the way, don't store the whole thing in memory, don't use byte arrays.
-            Often, functionality can be achieved in a streaming way.
-            Note: not a problem for small files.
+        <description>
+            Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
+            InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
+            ByteArrayOutputStream.toByteArray, and ResizableByteArrayOutputStream.toByteArray
+            load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
+            and slow responses when processing large files.
+            Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
+            Note: Not a problem for small files.
+            (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
+            <property name="tags"
+                      value="jpinpoint-rule,memory,performance,sustainability-medium"
+                      type="String"/>
             <property name="xpath">
                 <value><![CDATA[
-//MethodDeclaration//MethodCall[pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-]
+                    (: Java read-all file APIs :)
+                    //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
+                    ]
+                    (: Java read-all string APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
+                    ]
+                    (: Java InputStream read-all API :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+                    ]
+                    (: Apache Commons IO read-all APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
+                    ]
+                    (: ByteArrayInputStream allocation :)
+                    or //AllocationExpression[
+                           pmd-java:typeIs('java.io.ByteArrayInputStream')
+                    ]
+                    (: ByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
+                    (: ResizableByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
                 ]]></value>
             </property>
         </properties>
-        <example>
-            <![CDATA[
+
+        <example><![CDATA[
 class Bad {
-    void bad(Path path) {
-        byte[] fileBytes = Files.readAllBytes(path); // bad
-        List<String> fileLines = Files.readAllLines(path); // bad
-        // process bytes / lines
+    void bad(Path path, InputStream in) throws Exception {
+        byte[] fileBytes = Files.readAllBytes(path);                        // bad
+        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
+
+        String s = Files.readString(path);                                  // bad
+        byte[] full = IOUtils.toByteArray(in);                              // bad
+        ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] arr = baos.toByteArray();                                    // bad
     }
 }
 
 class Good {
-    void good(Path in) throws IOException {
-        try (BufferedReader reader = Files.newBufferedReader(in)) {
-            String line = reader.readLine();
-            // process line by line
+    void good(Path path, InputStream in) throws Exception {
+        try (InputStream s = Files.newInputStream(path)) {
+            IOUtils.copy(s, System.out);                                    // streaming OK
+        }
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line = reader.readLine();                                // streaming OK
         }
     }
 }
-            ]]>
-        </example>
+]]>     </example>
     </rule>
 
     <rule name="AvoidLombokAnnotationForNonExistentFields"
@@ -6124,10 +6171,9 @@ return HttpClientBuilder.create() // good, setConnectionManager called, pool con
           language="java"
           message="Apache HttpClient builder is used and not all three timeouts are configured."
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#IBI10">
-        <description>Problem: for connectionRequestTimeout, connectTimeout, socketTimeout (using
-            HttpComponentsClientHttpRequestFactory/RequestConfig) or readTimeout/responseTimeout (using RequestConfig v4/v5) and connectTimeout (using ConnectionConfig v5)
-            the default timeout settings are not optimal in most cases. &#13;
-            Solution: Set the timeouts explicitly to proper reasoned values. See best practice values via the link. Use
+        <description>Problem: default timeout values for Apache HttpClient are often sub optimal (connectionRequestTimeout, connectTimeout, socketTimeout in HttpComponentsClientHttpRequestFactory;
+            readTimeout/responseTimeout in RequestConfig v4/v5; and connectTimeout in ConnectionConfig v5) &#13;
+            Solution: Set all these timeouts explicitly to proper reasoned values. See best practice values via the link. Use
             the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the
             timeouts. (jpinpoint-rules)
         (jpinpoint-rules)</description>

--- a/rulesets/java/jpinpoint-java-rules.xml
+++ b/rulesets/java/jpinpoint-java-rules.xml
@@ -492,7 +492,8 @@ class IterationsBetter {
             load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
             and slow responses when processing large files.
             Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
-            Note: Not a problem for small files.
+            Note: Not a problem for small files. In that case use e.g.:
+            @SuppressWarnings("PMD.AvoidLoadingAllFromFile") // only small files: max 1 kB.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>

--- a/rulesets/java/jpinpoint-java-rules.xml
+++ b/rulesets/java/jpinpoint-java-rules.xml
@@ -481,11 +481,10 @@ class IterationsBetter {
     </rule>
 
     <rule name="AvoidLoadingAllFromFile"
-        language="java"
-        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
-        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
-
+          language="java"
+          message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
         <description>
             Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
             InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
@@ -498,60 +497,26 @@ class IterationsBetter {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags"
-                      value="jpinpoint-rule,memory,performance,sustainability-medium"
-                      type="String"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
-                    (: Java read-all file APIs :)
-                    //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-                    ]
-                    (: Java read-all string APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
-                    ]
-                    (: Java InputStream read-all API :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
-                    ]
-                    (: Apache Commons IO read-all APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
-                    ]
-                    (: ByteArrayInputStream allocation :)
-                    or //AllocationExpression[
-                           pmd-java:typeIs('java.io.ByteArrayInputStream')
-                    ]
-                    (: ByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                    (: ResizableByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                ]]></value>
+//MethodCall[
+    (TypeExpression[pmd-java:typeIs('java.nio.file.Files')] and @MethodName=('readAllBytes', 'readAllLines', 'readString'))
+    or pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+    or (TypeExpression[pmd-java:typeIs('org.apache.commons.io.IOUtils')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('java.io.ByteArrayOutputStream')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')] and @MethodName='toByteArray')
+]
+|
+//ConstructorCall[pmd-java:typeIs('java.io.ByteArrayInputStream')]
+    ]]></value>
             </property>
         </properties>
-
         <example><![CDATA[
 class Bad {
     void bad(Path path, InputStream in) throws Exception {
         byte[] fileBytes = Files.readAllBytes(path);                        // bad
-        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
-
+        List<String> fileLines = Files.readAllLines(path);                  // bad
         String s = Files.readString(path);                                  // bad
         byte[] full = IOUtils.toByteArray(in);                              // bad
         ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad
@@ -559,7 +524,6 @@ class Bad {
         byte[] arr = baos.toByteArray();                                    // bad
     }
 }
-
 class Good {
     void good(Path path, InputStream in) throws Exception {
         try (InputStream s = Files.newInputStream(path)) {
@@ -570,7 +534,8 @@ class Good {
         }
     }
 }
-]]>     </example>
+]]>
+        </example>
     </rule>
 
     <rule name="AvoidLombokAnnotationForNonExistentFields"

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -481,49 +481,96 @@ class IterationsBetter {
     </rule>
 
     <rule name="AvoidLoadingAllFromFile"
-          language="java"
-          message="Files.readAll methods load all bytes from a file into memory: a risk of memory problems."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        language="java"
+        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
 
-          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
-        <description>Problem: Files.readAllBytes and Files.readAllLines load all bytes from a file into the heap memory.
-            This may result in an OutOfMemoryError crash, or long gc pauses and slow responses.
-            Solution: Stream-through: use streaming all the way, don't store the whole thing in memory, don't use byte arrays.
-            Often, functionality can be achieved in a streaming way.
-            Note: not a problem for small files.
+        <description>
+            Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
+            InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
+            ByteArrayOutputStream.toByteArray, and ResizableByteArrayOutputStream.toByteArray
+            load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
+            and slow responses when processing large files.
+            Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
+            Note: Not a problem for small files.
+            (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
+            <property name="tags"
+                      value="jpinpoint-rule,memory,performance,sustainability-medium"
+                      type="String"/>
             <property name="xpath">
                 <value><![CDATA[
-//MethodDeclaration//MethodCall[pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-]
+                    (: Java read-all file APIs :)
+                    //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
+                    ]
+                    (: Java read-all string APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
+                    ]
+                    (: Java InputStream read-all API :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+                    ]
+                    (: Apache Commons IO read-all APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
+                    ]
+                    (: ByteArrayInputStream allocation :)
+                    or //AllocationExpression[
+                           pmd-java:typeIs('java.io.ByteArrayInputStream')
+                    ]
+                    (: ByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
+                    (: ResizableByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
                 ]]></value>
             </property>
         </properties>
-        <example>
-            <![CDATA[
+
+        <example><![CDATA[
 class Bad {
-    void bad(Path path) {
-        byte[] fileBytes = Files.readAllBytes(path); // bad
-        List<String> fileLines = Files.readAllLines(path); // bad
-        // process bytes / lines
+    void bad(Path path, InputStream in) throws Exception {
+        byte[] fileBytes = Files.readAllBytes(path);                        // bad
+        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
+
+        String s = Files.readString(path);                                  // bad
+        byte[] full = IOUtils.toByteArray(in);                              // bad
+        ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] arr = baos.toByteArray();                                    // bad
     }
 }
 
 class Good {
-    void good(Path in) throws IOException {
-        try (BufferedReader reader = Files.newBufferedReader(in)) {
-            String line = reader.readLine();
-            // process line by line
+    void good(Path path, InputStream in) throws Exception {
+        try (InputStream s = Files.newInputStream(path)) {
+            IOUtils.copy(s, System.out);                                    // streaming OK
+        }
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line = reader.readLine();                                // streaming OK
         }
     }
 }
-            ]]>
-        </example>
+]]>     </example>
     </rule>
 
     <rule name="AvoidLombokAnnotationForNonExistentFields"
@@ -6124,10 +6171,9 @@ return HttpClientBuilder.create() // good, setConnectionManager called, pool con
           language="java"
           message="Apache HttpClient builder is used and not all three timeouts are configured."
           externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#IBI10">
-        <description>Problem: for connectionRequestTimeout, connectTimeout, socketTimeout (using
-            HttpComponentsClientHttpRequestFactory/RequestConfig) or readTimeout/responseTimeout (using RequestConfig v4/v5) and connectTimeout (using ConnectionConfig v5)
-            the default timeout settings are not optimal in most cases. &#13;
-            Solution: Set the timeouts explicitly to proper reasoned values. See best practice values via the link. Use
+        <description>Problem: default timeout values for Apache HttpClient are often sub optimal (connectionRequestTimeout, connectTimeout, socketTimeout in HttpComponentsClientHttpRequestFactory;
+            readTimeout/responseTimeout in RequestConfig v4/v5; and connectTimeout in ConnectionConfig v5) &#13;
+            Solution: Set all these timeouts explicitly to proper reasoned values. See best practice values via the link. Use
             the setDefaultRequestConfig with a method with a RequestConfig object on HttpClient builders to set the
             timeouts. (jpinpoint-rules)
         (jpinpoint-rules)</description>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -492,7 +492,8 @@ class IterationsBetter {
             load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
             and slow responses when processing large files.
             Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
-            Note: Not a problem for small files.
+            Note: Not a problem for small files. In that case use e.g.:
+            @SuppressWarnings("PMD.AvoidLoadingAllFromFile") // only small files: max 1 kB.
             (jpinpoint-rules)
         (jpinpoint-rules)</description>
         <priority>2</priority>

--- a/rulesets/java/jpinpoint-rules.xml
+++ b/rulesets/java/jpinpoint-rules.xml
@@ -481,11 +481,10 @@ class IterationsBetter {
     </rule>
 
     <rule name="AvoidLoadingAllFromFile"
-        language="java"
-        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
-        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
-
+          language="java"
+          message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
         <description>
             Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
             InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
@@ -498,60 +497,26 @@ class IterationsBetter {
         (jpinpoint-rules)</description>
         <priority>2</priority>
         <properties>
-            <property name="tags"
-                      value="jpinpoint-rule,memory,performance,sustainability-medium"
-                      type="String"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
-                    (: Java read-all file APIs :)
-                    //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-                    ]
-                    (: Java read-all string APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
-                    ]
-                    (: Java InputStream read-all API :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
-                    ]
-                    (: Apache Commons IO read-all APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
-                    ]
-                    (: ByteArrayInputStream allocation :)
-                    or //AllocationExpression[
-                           pmd-java:typeIs('java.io.ByteArrayInputStream')
-                    ]
-                    (: ByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                    (: ResizableByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                ]]></value>
+//MethodCall[
+    (TypeExpression[pmd-java:typeIs('java.nio.file.Files')] and @MethodName=('readAllBytes', 'readAllLines', 'readString'))
+    or pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+    or (TypeExpression[pmd-java:typeIs('org.apache.commons.io.IOUtils')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('java.io.ByteArrayOutputStream')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')] and @MethodName='toByteArray')
+]
+|
+//ConstructorCall[pmd-java:typeIs('java.io.ByteArrayInputStream')]
+    ]]></value>
             </property>
         </properties>
-
         <example><![CDATA[
 class Bad {
     void bad(Path path, InputStream in) throws Exception {
         byte[] fileBytes = Files.readAllBytes(path);                        // bad
-        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
-
+        List<String> fileLines = Files.readAllLines(path);                  // bad
         String s = Files.readString(path);                                  // bad
         byte[] full = IOUtils.toByteArray(in);                              // bad
         ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad
@@ -559,7 +524,6 @@ class Bad {
         byte[] arr = baos.toByteArray();                                    // bad
     }
 }
-
 class Good {
     void good(Path path, InputStream in) throws Exception {
         try (InputStream s = Files.newInputStream(path)) {
@@ -570,7 +534,8 @@ class Good {
         }
     }
 }
-]]>     </example>
+]]>
+        </example>
     </rule>
 
     <rule name="AvoidLombokAnnotationForNonExistentFields"

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2139,13 +2139,11 @@ class Foo {
         </example>
     </rule>
 
-
     <rule name="AvoidLoadingAllFromFile"
-        language="java"
-        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
-        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
-
+          language="java"
+          message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${doc_root}/JavaCodePerformance.md#isio03">
         <description>
             Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
             InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
@@ -2158,59 +2156,26 @@ class Foo {
         </description>
         <priority>2</priority>
         <properties>
-            <property name="tags"
-                      value="jpinpoint-rule,memory,performance,sustainability-medium"
-                      type="String"/>
+            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
             <property name="xpath">
                 <value><![CDATA[
-                    (: Java read-all file APIs :)
-                    //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-                    ]
-                    (: Java read-all string APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
-                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
-                    ]
-                    (: Java InputStream read-all API :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
-                    ]
-                    (: Apache Commons IO read-all APIs :)
-                    or //MethodCall[
-                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
-                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
-                    ]
-                    (: ByteArrayInputStream allocation :)
-                    or //AllocationExpression[
-                           pmd-java:typeIs('java.io.ByteArrayInputStream')
-                    ]
-                    (: ByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                    (: ResizableByteArrayOutputStream.toByteArray :)
-                    or //PrimaryExpression[
-                           PrimaryPrefix/Name[
-                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
-                               and ends-with(@Image, 'toByteArray')
-                           ]
-                    ]
-                ]]></value>
+//MethodCall[
+    (TypeExpression[pmd-java:typeIs('java.nio.file.Files')] and @MethodName=('readAllBytes', 'readAllLines', 'readString'))
+    or pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+    or (TypeExpression[pmd-java:typeIs('org.apache.commons.io.IOUtils')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('java.io.ByteArrayOutputStream')] and @MethodName='toByteArray')
+    or (VariableAccess[pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')] and @MethodName='toByteArray')
+]
+|
+//ConstructorCall[pmd-java:typeIs('java.io.ByteArrayInputStream')]
+    ]]></value>
             </property>
         </properties>
         <example><![CDATA[
 class Bad {
     void bad(Path path, InputStream in) throws Exception {
         byte[] fileBytes = Files.readAllBytes(path);                        // bad
-        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
-
+        List<String> fileLines = Files.readAllLines(path);                  // bad
         String s = Files.readString(path);                                  // bad
         byte[] full = IOUtils.toByteArray(in);                              // bad
         ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2141,74 +2141,72 @@ class Foo {
 
 
     <rule name="AvoidLoadingAllFromFile"
-    language="java"
-    message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
-    class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-    externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
+        language="java"
+        message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
 
-    <description>
-        Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
-        InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
-        ByteArrayOutputStream.toByteArray, and ResizableByteArrayOutputStream.toByteArray
-        load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
-        and slow responses when processing large files.
-        Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
-        Note: Not a problem for small files.
-        (jpinpoint-rules)
-    </description>
-    <priority>2</priority>
-    <properties>
-        <property name="tags"
-                  value="jpinpoint-rule,memory,performance,sustainability-medium"
-                  type="String"/>
-        <property name="xpath">
-            <value><![CDATA[
-                (: Java read-all file APIs :)
-                //MethodCall[
-                       pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-                    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-                    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-                ]
-                (: Java read-all string APIs :)
-                or //MethodCall[
-                       pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
-                    or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
-                ]
-                (: Java InputStream read-all API :)
-                or //MethodCall[
-                       pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
-                ]
-                (: Apache Commons IO read-all APIs :)
-                or //MethodCall[
-                       pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
-                    or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
-                    or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
-                ]
-                (: ByteArrayInputStream allocation :)
-                or //AllocationExpression[
-                       pmd-java:typeIs('java.io.ByteArrayInputStream')
-                ]
-                (: ByteArrayOutputStream.toByteArray :)
-                or //PrimaryExpression[
-                       PrimaryPrefix/Name[
-                           pmd-java:typeIs('java.io.ByteArrayOutputStream')
-                           and ends-with(@Image, 'toByteArray')
-                       ]
-                ]
-                (: ResizableByteArrayOutputStream.toByteArray :)
-                or //PrimaryExpression[
-                       PrimaryPrefix/Name[
-                           pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
-                           and ends-with(@Image, 'toByteArray')
-                       ]
-                ]
-            ]]></value>
-        </property>
-    </properties>
-
-    <example><![CDATA[
+        <description>
+            Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
+            InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
+            ByteArrayOutputStream.toByteArray, and ResizableByteArrayOutputStream.toByteArray
+            load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
+            and slow responses when processing large files.
+            Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
+            Note: Not a problem for small files.
+            (jpinpoint-rules)
+        </description>
+        <priority>2</priority>
+        <properties>
+            <property name="tags"
+                      value="jpinpoint-rule,memory,performance,sustainability-medium"
+                      type="String"/>
+            <property name="xpath">
+                <value><![CDATA[
+                    (: Java read-all file APIs :)
+                    //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
+                    ]
+                    (: Java read-all string APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
+                        or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
+                    ]
+                    (: Java InputStream read-all API :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+                    ]
+                    (: Apache Commons IO read-all APIs :)
+                    or //MethodCall[
+                           pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
+                        or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
+                    ]
+                    (: ByteArrayInputStream allocation :)
+                    or //AllocationExpression[
+                           pmd-java:typeIs('java.io.ByteArrayInputStream')
+                    ]
+                    (: ByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('java.io.ByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
+                    (: ResizableByteArrayOutputStream.toByteArray :)
+                    or //PrimaryExpression[
+                           PrimaryPrefix/Name[
+                               pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
+                               and ends-with(@Image, 'toByteArray')
+                           ]
+                    ]
+                ]]></value>
+            </property>
+        </properties>
+        <example><![CDATA[
 class Bad {
-
     void bad(Path path, InputStream in) throws Exception {
         byte[] fileBytes = Files.readAllBytes(path);                        // bad
         java.util.List<String> fileLines = Files.readAllLines(path);        // bad
@@ -2220,7 +2218,6 @@ class Bad {
         byte[] arr = baos.toByteArray();                                    // bad
     }
 }
-
 class Good {
     void good(Path path, InputStream in) throws Exception {
         try (InputStream s = Files.newInputStream(path)) {
@@ -2231,7 +2228,8 @@ class Good {
         }
     }
 }
-]]></example>
+]]>
+        </example>
     </rule>
 
     <rule name="HashCodeOnlyCallsSuper"

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2139,50 +2139,99 @@ class Foo {
         </example>
     </rule>
 
-    <rule name="AvoidLoadingAllFromFile"
-          language="java"
-          message="Files.readAll methods load all bytes from a file into memory: a risk of memory problems."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
 
-          externalInfoUrl="${doc_root}/JavaCodePerformance.md#isio03">
-        <description>Problem: Files.readAllBytes and Files.readAllLines load all bytes from a file into the heap memory.
-            This may result in an OutOfMemoryError crash, or long gc pauses and slow responses.
-            Solution: Stream-through: use streaming all the way, don't store the whole thing in memory, don't use byte arrays.
-            Often, functionality can be achieved in a streaming way.
-            Note: not a problem for small files.
-        </description>
-        <priority>2</priority>
-        <properties>
-            <property name="tags" value="jpinpoint-rule,memory,performance,sustainability-medium" type="String" description="classification"/>
-            <property name="xpath">
-                <value><![CDATA[
-//MethodDeclaration//MethodCall[pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
-    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
-]
-                ]]></value>
-            </property>
-        </properties>
-        <example>
-            <![CDATA[
+    <rule name="AvoidLoadingAllFromFile"
+    language="java"
+    message="Files.readAll methods and similar APIs load all bytes into memory: a risk of memory problems."
+    class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+    externalInfoUrl="https://github.com/jborgers/PMD-jPinpoint-rules/tree/pmd7/docs/JavaCodePerformance.md#isio03">
+
+    <description>
+        Problem: APIs like Files.readAllBytes, Files.readAllLines, Files.readString,
+        InputStream.readAllBytes, IOUtils.toByteArray, ByteArrayInputStream,
+        ByteArrayOutputStream.toByteArray, and ResizableByteArrayOutputStream.toByteArray
+        load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
+        and slow responses when processing large files.
+        Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
+        Note: Not a problem for small files.
+        (jpinpoint-rules)
+    </description>
+    <priority>2</priority>
+    <properties>
+        <property name="tags"
+                  value="jpinpoint-rule,memory,performance,sustainability-medium"
+                  type="String"/>
+        <property name="xpath">
+            <value><![CDATA[
+                (: Java read-all file APIs :)
+                //MethodCall[
+                       pmd-java:matchesSig('java.nio.file.Files#readAllBytes(java.nio.file.Path)')
+                    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path)')
+                    or pmd-java:matchesSig('java.nio.file.Files#readAllLines(java.nio.file.Path,_)')
+                ]
+                (: Java read-all string APIs :)
+                or //MethodCall[
+                       pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path)')
+                    or pmd-java:matchesSig('java.nio.file.Files#readString(java.nio.file.Path,_)')
+                ]
+                (: Java InputStream read-all API :)
+                or //MethodCall[
+                       pmd-java:matchesSig('java.io.InputStream#readAllBytes()')
+                ]
+                (: Apache Commons IO read-all APIs :)
+                or //MethodCall[
+                       pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)')
+                    or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.net.URL)')
+                    or pmd-java:matchesSig('org.apache.commons.io.IOUtils#toByteArray(java.nio.file.Path)')
+                ]
+                (: ByteArrayInputStream allocation :)
+                or //AllocationExpression[
+                       pmd-java:typeIs('java.io.ByteArrayInputStream')
+                ]
+                (: ByteArrayOutputStream.toByteArray :)
+                or //PrimaryExpression[
+                       PrimaryPrefix/Name[
+                           pmd-java:typeIs('java.io.ByteArrayOutputStream')
+                           and ends-with(@Image, 'toByteArray')
+                       ]
+                ]
+                (: ResizableByteArrayOutputStream.toByteArray :)
+                or //PrimaryExpression[
+                       PrimaryPrefix/Name[
+                           pmd-java:typeIs('org.springframework.util.ResizableByteArrayOutputStream')
+                           and ends-with(@Image, 'toByteArray')
+                       ]
+                ]
+            ]]></value>
+        </property>
+    </properties>
+
+    <example><![CDATA[
 class Bad {
-    void bad(Path path) {
-        byte[] fileBytes = Files.readAllBytes(path); // bad
-        List<String> fileLines = Files.readAllLines(path); // bad
-        // process bytes / lines
+
+    void bad(Path path, InputStream in) throws Exception {
+        byte[] fileBytes = Files.readAllBytes(path);                        // bad
+        java.util.List<String> fileLines = Files.readAllLines(path);        // bad
+
+        String s = Files.readString(path);                                  // bad
+        byte[] full = IOUtils.toByteArray(in);                              // bad
+        ByteArrayInputStream bis = new ByteArrayInputStream(full);          // bad
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] arr = baos.toByteArray();                                    // bad
     }
 }
 
 class Good {
-    void good(Path in) throws IOException {
-        try (BufferedReader reader = Files.newBufferedReader(in)) {
-            String line = reader.readLine();
-            // process line by line
+    void good(Path path, InputStream in) throws Exception {
+        try (InputStream s = Files.newInputStream(path)) {
+            IOUtils.copy(s, System.out);                                    // streaming OK
+        }
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line = reader.readLine();                                // streaming OK
         }
     }
 }
-            ]]>
-        </example>
+]]></example>
     </rule>
 
     <rule name="HashCodeOnlyCallsSuper"

--- a/src/main/resources/category/java/common.xml
+++ b/src/main/resources/category/java/common.xml
@@ -2151,7 +2151,8 @@ class Foo {
             load entire content into heap memory. This risks OutOfMemoryError, long GC pauses,
             and slow responses when processing large files.
             Solution: Use streaming APIs end-to-end, do not buffer whole files in memory.
-            Note: Not a problem for small files.
+            Note: Not a problem for small files. In that case use e.g.:
+            @SuppressWarnings("PMD.AvoidLoadingAllFromFile") // only small files: max 1 kB.
             (jpinpoint-rules)
         </description>
         <priority>2</priority>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidLoadingAllFromFile.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidLoadingAllFromFile.xml
@@ -32,4 +32,66 @@ class Good {
      ]]></code>
     </test-code>
 
+    <test-code>
+        <description>violations: Extended AvoidLoadingAllFromFile rule</description>
+
+        <expected-problems>12</expected-problems>
+        <expected-linenumbers>
+            11, 12, 13, 14, 15,
+            18, 19, 20,
+            23,
+            28,
+            32,
+            35
+        </expected-linenumbers>
+
+        <code><![CDATA[
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.nio.charset.*;
+import org.apache.commons.io.IOUtils;
+import org.springframework.util.ResizableByteArrayOutputStream;
+
+class Bad_Issue697 {
+    void bad(Path path, InputStream in, URL url) throws Exception {
+
+        byte[] b1 = Files.readAllBytes(path);              // bad line 11
+        var l1 = Files.readAllLines(path);                 // bad line 12
+        var l2 = Files.readAllLines(path, Charset.defaultCharset()); // bad line 13
+        var s1 = Files.readString(path);                   // bad line 14
+        var s2 = Files.readString(path, Charset.defaultCharset()); // bad line 15
+
+        byte[] b2 = in.readAllBytes();                     // bad line 18
+        byte[] b3 = IOUtils.toByteArray(in);               // bad line 19
+        byte[] b4 = IOUtils.toByteArray(url);              // bad line 20
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(b1); // bad line 23
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] arr = baos.toByteArray();                   // bad line 28
+
+        ResizableByteArrayOutputStream rbaos =
+            new ResizableByteArrayOutputStream();          // OK (constructor only)
+
+        byte[] arr2 = rbaos.toByteArray();                 // bad line 32
+
+        byte[] arr3 = IOUtils.toByteArray(path);           // bad line 35
+    }
+}
+
+class Good_Issue697 {
+    void good(Path path, InputStream in) throws Exception {
+        try (InputStream s = Files.newInputStream(path)) {
+            IOUtils.copy(s, System.out);          // streaming OK
+        }
+        try (BufferedInputStream bin = new BufferedInputStream(in)) {
+            int c = bin.read();                   // streaming OK
+        }
+        // No violations expected
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidLoadingAllFromFile.xml
+++ b/src/test/resources/com/jpinpoint/perf/lang/java/ruleset/common/xml/AvoidLoadingAllFromFile.xml
@@ -34,17 +34,8 @@ class Good {
 
     <test-code>
         <description>violations: Extended AvoidLoadingAllFromFile rule</description>
-
         <expected-problems>12</expected-problems>
-        <expected-linenumbers>
-            11, 12, 13, 14, 15,
-            18, 19, 20,
-            23,
-            28,
-            32,
-            35
-        </expected-linenumbers>
-
+        <expected-linenumbers>11, 12, 13, 14, 15,  17, 18, 19,  21, 24, 28, 30</expected-linenumbers>
         <code><![CDATA[
 import java.io.*;
 import java.net.*;
@@ -62,21 +53,20 @@ class Bad_Issue697 {
         var s1 = Files.readString(path);                   // bad line 14
         var s2 = Files.readString(path, Charset.defaultCharset()); // bad line 15
 
-        byte[] b2 = in.readAllBytes();                     // bad line 18
-        byte[] b3 = IOUtils.toByteArray(in);               // bad line 19
-        byte[] b4 = IOUtils.toByteArray(url);              // bad line 20
+        byte[] b2 = in.readAllBytes();                     // bad line 17
+        byte[] b3 = IOUtils.toByteArray(in);               // bad line 18
+        byte[] b4 = IOUtils.toByteArray(url);              // bad line 19
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(b1); // bad line 23
+        ByteArrayInputStream bis = new ByteArrayInputStream(b1); // bad line 21
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        byte[] arr = baos.toByteArray();                   // bad line 28
+        byte[] arr = baos.toByteArray();                   // bad line 24
 
         ResizableByteArrayOutputStream rbaos =
             new ResizableByteArrayOutputStream();          // OK (constructor only)
+        byte[] arr2 = rbaos.toByteArray();                 // bad line 29
 
-        byte[] arr2 = rbaos.toByteArray();                 // bad line 32
-
-        byte[] arr3 = IOUtils.toByteArray(path);           // bad line 35
+        byte[] arr3 = IOUtils.toByteArray(path);           // bad line 30
     }
 }
 


### PR DESCRIPTION
Extend AvoidLoadingAllFromFile with all major “load‑all‑into‑memory” patterns #697